### PR TITLE
Selection by double click of both origin and target text

### DIFF
--- a/app/components/Paragraph.tsx
+++ b/app/components/Paragraph.tsx
@@ -296,7 +296,7 @@ export const Paragraph = ({
       data-id={id}
       className={`relative h-full w-full rounded-xl ${
         isSelected
-          ? 'bg-gradient-to-r from-yellow-600 to-slate-700 p-0.5 pl-2 shadow-xl'
+          ? 'bg-gradient-to-r from-yellow-600 to-slate-700 p-2 shadow-xl'
           : `${isOrigin ? 'bg-card' : 'bg-card-foreground'} px-6 py-4 shadow-lg`
       } ${isUpdate ? 'animate-[pulse_1s_ease-in-out_1]' : ''}`}
     >

--- a/app/routes/_app.translation.$rollId.tsx
+++ b/app/routes/_app.translation.$rollId.tsx
@@ -277,9 +277,9 @@ export default function TranslationRoll() {
     <div key={paragraph.id} className="flex items-center gap-6 px-4">
       {paragraph?.target ? (
         <div
-          className={`${selectedParagraphIndex ? 'flex flex-col' : 'grid grid-cols-1 lg:grid-cols-2'} w-full gap-6 px-2 ${
+          className={`${selectedParagraphIndex ? 'flex flex-col' : 'grid grid-cols-1 lg:grid-cols-2'} w-full gap-2 px-2 ${
             selectedParagraphIndex === paragraph.id
-              ? 'rounded-xl bg-gradient-to-r from-yellow-600 to-slate-700 p-5 shadow-xl'
+              ? 'rounded-xl bg-gradient-to-r from-yellow-600 to-slate-700 p-2 shadow-xl'
               : ''
           }`}
         >
@@ -350,7 +350,11 @@ export default function TranslationRoll() {
         <DragPanel>
           <LeftPanel>
             <ScrollArea className="h-full w-full lg:pr-4">
-              <RadioGroup className="gap-4" onValueChange={setSelectedParagraphIndex}>
+              <RadioGroup
+                className="gap-4"
+                onValueChange={setSelectedParagraphIndex}
+                value={selectedParagraphIndex ?? undefined}
+              >
                 {Paragraphs}
               </RadioGroup>
             </ScrollArea>
@@ -370,7 +374,11 @@ export default function TranslationRoll() {
   return (
     <Fragment>
       <ScrollArea className="h-full px-0 lg:px-4">
-        <RadioGroup className="gap-4" onValueChange={setSelectedParagraphIndex}>
+        <RadioGroup
+          className="gap-4"
+          onValueChange={setSelectedParagraphIndex}
+          value={selectedParagraphIndex ?? undefined}
+        >
           {paragraphs.length ? (
             <>
               <p className="text-center text-lg lg:text-2xl">{rollInfo?.sutra.title}</p>


### PR DESCRIPTION
previously a paragraph could only be selected by double clicking the target. Now you can select by double clicking also the origin text.

also, the highlight used to be only around the origin text. Now it is around both the origin and target text.

fixes #95  #96 