### PR TITLE
make translator definable for original and translation

### DIFF
--- a/app/components/data/SutraForm.tsx
+++ b/app/components/data/SutraForm.tsx
@@ -75,6 +75,15 @@ export function SutraForm({ sutra, onClose }: { sutra?: SutraForForm; onClose: (
                 ))}
               </select>
             </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-primary-foreground/70">Translator</label>
+              <input
+                name="originTranslator"
+                className={inputClass(bg)}
+                placeholder="e.g., Xuanzang"
+                defaultValue={sutra?.translator}
+              />
+            </div>
           </div>
 
           {/* ── Translation column ── */}
@@ -111,11 +120,22 @@ export function SutraForm({ sutra, onClose }: { sutra?: SutraForForm; onClose: (
                 ))}
               </select>
             </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-primary-foreground/70">Translator</label>
+              <input
+                className={inputClass(bg)}
+                name="translationTranslator"
+                placeholder="e.g., Bhikkhu Bodhi"
+                defaultValue={sutra?.children?.translator ?? ''}
+              />
+            </div>
           </div>
         </div>
 
+        <hr className="border-primary-foreground/20" />
+
         {/* Metadata row */}
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           <div>
             <label className="mb-1 block text-xs font-medium text-primary-foreground/70">Category</label>
             <input
@@ -123,15 +143,6 @@ export function SutraForm({ sutra, onClose }: { sutra?: SutraForForm; onClose: (
               className={inputClass(bg)}
               defaultValue={sutra?.category}
               placeholder="e.g., Prajnaparamita"
-            />
-          </div>
-          <div>
-            <label className="mb-1 block text-xs font-medium text-primary-foreground/70">Translator</label>
-            <input
-              name="translator"
-              className={inputClass(bg)}
-              placeholder="e.g., Xuanzang"
-              defaultValue={sutra?.translator}
             />
           </div>
           <div>

--- a/app/components/data/SutraRow.tsx
+++ b/app/components/data/SutraRow.tsx
@@ -14,7 +14,15 @@ type Roll = {
   children?: { id: string; title: string; subtitle: string } | null;
 };
 
-type Sutra = SutraForForm & {
+type Sutra = {
+  id: string;
+  title: string;
+  subtitle: string | null;
+  language: string;
+  category: string;
+  translator: string;
+  cbeta: string;
+  children?: { id: string; title: string; subtitle: string | null; language: string; translator: string | null } | null;
   rolls?: Roll[] | null;
 };
 
@@ -49,7 +57,7 @@ export function SutraRow({
   const sutraForForm: SutraForForm = {
     id: sutra.id,
     title: sutra.title,
-    subtitle: sutra.subtitle,
+    subtitle: sutra.subtitle ?? '',
     language: sutra.language,
     category: sutra.category,
     translator: sutra.translator,
@@ -58,8 +66,9 @@ export function SutraRow({
       ? {
           id: sutra.children.id,
           title: sutra.children.title,
-          subtitle: sutra.children.subtitle,
+          subtitle: sutra.children.subtitle ?? '',
           language: sutra.children.language,
+          translator: sutra.children.translator ?? '',
         }
       : null,
   };

--- a/app/components/data/types.ts
+++ b/app/components/data/types.ts
@@ -1,12 +1,12 @@
 export type SutraForForm = {
   id: string;
   title: string;
-  subtitle?: string | null;
+  subtitle: string;
   language: string;
   category: string;
   translator: string;
   cbeta: string;
-  children?: { id: string; title: string; subtitle?: string | null; language: string } | null;
+  children?: { id: string; title: string; subtitle: string; language: string; translator: string } | null;
 };
 
 export type RollForForm = {

--- a/app/routes/_app.data._index.tsx
+++ b/app/routes/_app.data._index.tsx
@@ -26,11 +26,12 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       originTitle,
       originSubtitle,
       originLang,
+      originTranslator,
       translationTitle,
       translationSubtitle,
       translationLang,
+      translationTranslator,
       category,
-      translator,
       cbeta,
     } = parseSutraCreate(formData);
 
@@ -40,7 +41,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         subtitle: originSubtitle,
         language: originLang,
         category,
-        translator,
+        translator: originTranslator,
         cbeta,
         teamId: user.teamId,
       },
@@ -54,7 +55,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
           subtitle: translationSubtitle,
           language: translationLang,
           category,
-          translator,
+          translator: translationTranslator,
           cbeta,
           teamId: user.teamId,
           parentId: created.id,
@@ -74,17 +75,25 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       originTitle,
       originSubtitle,
       originLang,
+      originTranslator,
       translationTitle,
       translationSubtitle,
       translationLang,
+      translationTranslator,
       category,
-      translator,
       cbeta,
     } = parseSutraUpdate(formData);
 
     await updateSutra(
       sutraId,
-      { title: originTitle, subtitle: originSubtitle, language: originLang, category, translator, cbeta },
+      {
+        title: originTitle,
+        subtitle: originSubtitle,
+        language: originLang,
+        category,
+        translator: originTranslator,
+        cbeta,
+      },
       user,
     );
 
@@ -92,7 +101,13 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       if (childSutraId) {
         await updateSutra(
           childSutraId,
-          { title: translationTitle, subtitle: translationSubtitle, language: translationLang, category, translator },
+          {
+            title: translationTitle,
+            subtitle: translationSubtitle,
+            language: translationLang,
+            category,
+            translator: translationTranslator,
+          },
           user,
         );
       } else {
@@ -102,7 +117,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
             subtitle: translationSubtitle,
             language: translationLang,
             category,
-            translator,
+            translator: translationTranslator,
             cbeta,
             teamId: user.teamId,
             parentId: sutraId,

--- a/app/utils/dataFormParsers.ts
+++ b/app/utils/dataFormParsers.ts
@@ -4,13 +4,14 @@ import type { Lang } from '~/utils/constants';
 
 export type SutraCreatePayload = {
   originTitle: string;
-  originSubtitle: string | null;
+  originSubtitle: string;
   originLang: Lang;
+  originTranslator: string;
   translationTitle: string;
-  translationSubtitle: string | null;
+  translationSubtitle: string;
   translationLang: Lang;
+  translationTranslator: string;
   category: string;
-  translator: string;
   cbeta: string;
 };
 
@@ -22,13 +23,14 @@ export type SutraUpdatePayload = SutraCreatePayload & {
 export function parseSutraCreate(formData: FormData): SutraCreatePayload {
   return {
     originTitle: formData.get('originTitle') as string,
-    originSubtitle: (formData.get('originSubtitle') as string) || null,
+    originSubtitle: (formData.get('originSubtitle') as string) || '',
     originLang: formData.get('originLang') as Lang,
+    originTranslator: (formData.get('originTranslator') as string) || '',
     translationTitle: formData.get('translationTitle') as string,
-    translationSubtitle: (formData.get('translationSubtitle') as string) || null,
+    translationSubtitle: (formData.get('translationSubtitle') as string) || '',
     translationLang: formData.get('translationLang') as Lang,
+    translationTranslator: (formData.get('translationTranslator') as string) || '',
     category: (formData.get('category') as string) || '',
-    translator: (formData.get('translator') as string) || '',
     cbeta: (formData.get('cbeta') as string) || '',
   };
 }

--- a/tests/dataFormParsers.test.ts
+++ b/tests/dataFormParsers.test.ts
@@ -20,11 +20,12 @@ describe('parseSutraCreate', () => {
       originTitle: '大般若波羅蜜多經',
       originSubtitle: 'Origin subtitle',
       originLang: 'chinese',
+      originTranslator: 'Xuanzang',
       translationTitle: 'The Great Prajnaparamita Sutra',
       translationSubtitle: 'Translation subtitle',
       translationLang: 'english',
+      translationTranslator: 'Bhikkhu Bodhi',
       category: 'Prajnaparamita',
-      translator: 'Xuanzang',
       cbeta: 'T0220',
     });
 
@@ -32,11 +33,12 @@ describe('parseSutraCreate', () => {
       originTitle: '大般若波羅蜜多經',
       originSubtitle: 'Origin subtitle',
       originLang: 'chinese',
+      originTranslator: 'Xuanzang',
       translationTitle: 'The Great Prajnaparamita Sutra',
       translationSubtitle: 'Translation subtitle',
       translationLang: 'english',
+      translationTranslator: 'Bhikkhu Bodhi',
       category: 'Prajnaparamita',
-      translator: 'Xuanzang',
       cbeta: 'T0220',
     });
   });
@@ -46,11 +48,12 @@ describe('parseSutraCreate', () => {
       originTitle: '大般若',
       originSubtitle: '',
       originLang: 'chinese',
+      originTranslator: '',
       translationTitle: '',
       translationSubtitle: '',
       translationLang: '',
+      translationTranslator: '',
       category: '',
-      translator: '',
       cbeta: '',
     });
 
@@ -69,7 +72,8 @@ describe('parseSutraCreate', () => {
 
     const result = parseSutraCreate(fd);
     expect(result.category).toBe('');
-    expect(result.translator).toBe('');
+    expect(result.originTranslator).toBe('');
+    expect(result.translationTranslator).toBe('');
     expect(result.cbeta).toBe('');
   });
 });
@@ -83,10 +87,11 @@ describe('parseSutraUpdate', () => {
       childSutraId: 'child-456',
       originTitle: '大般若',
       originLang: 'chinese',
+      originTranslator: '',
       translationTitle: 'Great Sutra',
       translationLang: 'english',
+      translationTranslator: '',
       category: '',
-      translator: '',
       cbeta: '',
     });
 


### PR DESCRIPTION
translator could be different for english and chinese, so bring this into an original and translation level definition. also some work to get past the frequent type issues for null and undefined. the AI suggests anything that interacts with the database still needs null for nullable values, but when they move into the app, to channel values to empty string.