### PR TITLE
remove language filter for showing translation paragraphs, and exporting

### DIFF
--- a/app/routes/_app.resources.export.$rollId.tsx
+++ b/app/routes/_app.resources.export.$rollId.tsx
@@ -1,10 +1,8 @@
 import { type LoaderFunctionArgs } from '@vercel/remix';
 
-import type { Lang } from '~/utils/constants';
-
 import { assertAuthUser } from '~/auth.server';
 import { buildExportFilename, buildExportWorkbook, toExcelRows } from '~/services/file.service';
-import { readParagraphsByRollIdForLanguage } from '~/services/paragraph.service';
+import { readParagraphsByRollId } from '~/services/paragraph.service';
 
 export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const { rollId } = params;
@@ -13,7 +11,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const user = await assertAuthUser(request);
   if (!user) throw new Response('Unauthorized', { status: 401 });
 
-  const paragraphs = await readParagraphsByRollIdForLanguage({ rollId: rollId, language: user.originLang as Lang });
+  const paragraphs = await readParagraphsByRollId({ rollId: rollId });
 
   if (!paragraphs.length) {
     throw new Response('No data found for this roll', { status: 404 });

--- a/app/routes/_app.translation.$rollId.tsx
+++ b/app/routes/_app.translation.$rollId.tsx
@@ -9,7 +9,6 @@ import { ClientOnly } from 'remix-utils/client-only';
 import { ZodError } from 'zod';
 
 import type { ReadHistory } from '~/drizzle/tables/paragraph';
-import type { Lang } from '~/utils/constants';
 
 import { assertAuthUser } from '~/auth.server';
 import { Can } from '~/authorisation';
@@ -52,7 +51,7 @@ import { validatePayloadOrThrow } from '~/lib/payload.validation';
 import {
   createComment,
   insertParagraph,
-  readParagraphsByRollIdForLanguage,
+  readParagraphsByRollId,
   updateComment,
   updateParagraph,
   type IParagraph,
@@ -80,7 +79,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   }
   const { rollId } = params;
   const [paragraphs, rollInfo] = await Promise.all([
-    readParagraphsByRollIdForLanguage({ rollId: rollId as string, language: user.originLang as Lang }),
+    readParagraphsByRollId({ rollId: rollId as string }),
     readRollById(rollId as string),
   ]);
 

--- a/app/routes/_app.translation.tsx
+++ b/app/routes/_app.translation.tsx
@@ -13,7 +13,7 @@ import { Toaster } from '~/components/ui/toaster';
 import { type ReadRollWithSutra } from '~/drizzle/tables';
 import { useDownloadDocx } from '~/lib/hooks';
 import { readUsers } from '~/services';
-import { type IParagraph, readParagraphsByRollIdForLanguage } from '~/services/paragraph.service';
+import { type IParagraph, readParagraphsByRollId } from '~/services/paragraph.service';
 import { readRollById } from '~/services/roll.service';
 
 export const meta: MetaFunction = () => {
@@ -43,7 +43,7 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
   let rollInfo: ReadRollWithSutra | undefined = undefined;
   if (rollId) {
     [paragraphs, rollInfo] = await Promise.all([
-      readParagraphsByRollIdForLanguage({ rollId: rollId as string, language: user.originLang }),
+      readParagraphsByRollId({ rollId: rollId as string }),
       readRollById(rollId as string),
     ]);
   }


### PR DESCRIPTION
there were language filters against the users language setting in retrieving paragraphs, and exporting paragraphs. This kept the english language book from being seen.