### PR TITLE
show origin and target in translation selection

### DIFF
--- a/app/components/Card.tsx
+++ b/app/components/Card.tsx
@@ -1,23 +1,30 @@
 export const TranslationCard = ({
-  title,
-  subtitle,
-  translator,
+  originTitle,
+  originTranslator,
+  targetTitle,
+  targetTranslator,
   isSelected = false,
 }: {
-  title: string;
-  subtitle: string | null;
-  translator?: string;
+  originTitle: string;
+  originTranslator?: string;
+  targetTitle?: string | null;
+  targetTranslator?: string | null;
   isSelected?: boolean;
 }) => {
   return (
     <article className="hover:animate-background rounded-xl bg-gradient-to-r from-yellow-600 to-slate-700 p-0.5 shadow-xl transition hover:bg-[length:400%_400%] hover:shadow-sm hover:[animation-duration:_4s]">
       <div className={`rounded-[10px] p-4 sm:p-6 lg:!pt-10 ${isSelected ? 'bg-yellow-600' : 'bg-white'}`}>
-        <h3 className="mt-0.5 text-lg font-medium text-gray-900 lg:text-2xl">{title}</h3>
-        <h4 className="mt-1 text-sm font-medium text-gray-900">{translator}</h4>
-        <div className="mt-4 flex flex-wrap gap-1">
-          <span className="whitespace-wrap rounded-full bg-purple-100 px-2.5 py-0.5 text-xs text-primary">
-            {subtitle}
-          </span>
+        <div className={`grid gap-4 ${targetTitle ? 'grid-cols-2' : 'grid-cols-1'}`}>
+          <div>
+            <h3 className="mt-0.5 text-lg font-medium text-gray-900 lg:text-2xl">{originTitle}</h3>
+            {originTranslator && <h4 className="mt-1 text-sm font-medium text-gray-900">{originTranslator}</h4>}
+          </div>
+          {targetTitle && (
+            <div className="border-l border-gray-200 pl-4">
+              <h3 className="mt-0.5 text-lg font-medium text-gray-900 lg:text-2xl">{targetTitle}</h3>
+              {targetTranslator && <h4 className="mt-1 text-sm font-medium text-gray-900">{targetTranslator}</h4>}
+            </div>
+          )}
         </div>
       </div>
     </article>

--- a/app/routes/_app.translation._index.tsx
+++ b/app/routes/_app.translation._index.tsx
@@ -108,10 +108,11 @@ export default function TranslationIndex() {
       {sutra.children ? (
         <div onClick={() => setSutraId(sutra.id)}>
           <TranslationCard
-            title={sutra.title}
-            subtitle={sutra.category}
-            translator={sutra.translator}
+            originTitle={sutra.title}
             isSelected={sutraId === sutra.id}
+            targetTitle={sutra.children.title}
+            originTranslator={sutra.translator}
+            targetTranslator={sutra.children.translator}
           />
         </div>
       ) : (
@@ -120,7 +121,7 @@ export default function TranslationIndex() {
           title={`Create ${context.user.targetLang} sutra`}
           trigger={
             <Link to={`/translation?sutraId=${sutra.id}`}>
-              <TranslationCard title={sutra.title} subtitle={sutra.category} translator={sutra.translator} />
+              <TranslationCard originTitle={sutra.title} originTranslator={sutra.translator} />
             </Link>
           }
         >
@@ -160,7 +161,7 @@ export default function TranslationIndex() {
     >
       {roll.children ? (
         <Link to={`/translation/${roll.id}`}>
-          <TranslationCard title={roll.title} subtitle={roll.subtitle} />
+          <TranslationCard originTitle={roll.title} targetTitle={roll.children.title} />
         </Link>
       ) : (
         <FormModal
@@ -168,7 +169,7 @@ export default function TranslationIndex() {
           title={`Create ${context.user.targetLang} roll`}
           trigger={
             <Link to={`/translation?sutraId=${targetSutraId}&rollId=${roll.id}`}>
-              <TranslationCard title={roll.title} subtitle={roll.subtitle} />
+              <TranslationCard originTitle={roll.title} />
             </Link>
           }
         >


### PR DESCRIPTION
shows target titles and translators in sutra and roll cards, in translation tab.
removes the subtitle formatting, which looks like a category.