### PR TITLE
Glossary replace

### DIFF
--- a/app/authorisation/ability.ts
+++ b/app/authorisation/ability.ts
@@ -14,7 +14,9 @@ type Subjects =
   | 'Comment'
   | 'History';
 
-export const defineAbilityFor = (user: ReadUser) => {
+// Only the role is consulted, so callers may pass anything role-shaped — a full ReadUser,
+// or a bare { role } recovered from a loader.
+export const defineAbilityFor = (user: Pick<ReadUser, 'role'>) => {
   const { can, build } = new AbilityBuilder(PureAbility<[Actions, Subjects]>);
   if (user.role === 'admin') {
     can('Read', 'Administration');
@@ -47,12 +49,21 @@ export const defineAbilityFor = (user: ReadUser) => {
   if (user.role === 'admin' || user.role === 'editor' || user.role === 'manager' || user.role === 'leader') {
     can('Read', 'Translation');
   }
-  if (user.role === 'admin' || user.role === 'editor' || user.role === 'leader') {
+  // ── Glossary ──
+  // Manager holds Read DataManagement, so it also needs write access for the /data/glossary
+  // tools to be usable rather than merely visible.
+  if (user.role === 'admin' || user.role === 'editor' || user.role === 'leader' || user.role === 'manager') {
     can('Update', 'Glossary');
   }
-  if (user.role === 'admin') {
+  // Gates bulk import (/data/glossary/import), which creates entries as well as updating them.
+  // Exporting the whole glossary as CSV — /glossary/download and /data/glossary/download.
+  if (user.role === 'admin' || user.role === 'manager') {
     can('Create', 'Glossary');
     can('Download', 'Glossary');
+  }
+  if (user.role === 'admin') {
+    // Wholesale replacement of the glossary — see /data/glossary/replace.
+    can('Delete', 'Glossary');
   }
   return build();
 };

--- a/app/components/SideBarMenu.tsx
+++ b/app/components/SideBarMenu.tsx
@@ -1,3 +1,4 @@
+import { useAbility } from '@casl/react';
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { Form, Link, NavLink, useFetcher, useLocation, useNavigation } from '@remix-run/react';
 import { useDebounce } from '@uidotdev/usehooks';
@@ -6,6 +7,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { ClientOnly } from 'remix-utils/client-only';
 import { match } from 'ts-pattern';
 
+import { AbilityContext } from '~/authorisation';
 import {
   Avatar,
   AvatarFallback,
@@ -65,6 +67,12 @@ export function SideBarMenu({
   const { isOpen, setIsOpen } = useSideBarMenuContext();
   const [dataMenuOpen, setDataMenuOpen] = useState(() => pathname.startsWith('/data'));
 
+  // Which entries appear is decided by ability.ts, not by role checks spelled out here,
+  // so the menu can't drift from what the routes actually allow.
+  const ability = useAbility(AbilityContext);
+  const canReadAdmin = ability.can('Read', 'Administration');
+  const canManageData = ability.can('Read', 'DataManagement');
+
   useEffect(() => {
     if (pathname.startsWith('/data')) {
       setDataMenuOpen(true);
@@ -116,12 +124,7 @@ export function SideBarMenu({
 
         <nav className="flex w-full flex-1 flex-col gap-1 border-y border-yellow-600 py-4">
           {menuItems
-            .filter((item) => {
-              if (item.href.includes('admin') && userRole !== 'admin') {
-                return false;
-              }
-              return true;
-            })
+            .filter((item) => item.href !== '/admin' || canReadAdmin)
             .map((item) => (
               <Tooltip key={item.href} delayDuration={500}>
                 <TooltipTrigger asChild>
@@ -151,7 +154,7 @@ export function SideBarMenu({
               </Tooltip>
             ))}
 
-          {(userRole === 'admin' || userRole === 'manager') && (
+          {canManageData && (
             <div>
               <Tooltip delayDuration={500}>
                 <TooltipTrigger asChild>

--- a/app/routes/_app.data.glossary._index.tsx
+++ b/app/routes/_app.data.glossary._index.tsx
@@ -68,6 +68,22 @@ function ImportGlossaryLink() {
   );
 }
 
+function ReplaceGlossaryLink() {
+  return (
+    <div className="flex items-center gap-3">
+      <Button asChild>
+        <Link to="/data/glossary/replace">
+          <Icons.Add className="mr-2 h-4 w-4" />
+          Go to Replace Page
+        </Link>
+      </Button>
+      <p className="text-muted-foreground text-sm">
+        Upload a CSV to discard the current glossary and replace it with the file&apos;s entries.
+      </p>
+    </div>
+  );
+}
+
 export default function DataGlossary() {
   return (
     <div className="container mx-auto max-w-5xl space-y-6 p-6">
@@ -92,6 +108,21 @@ export default function DataGlossary() {
         </CardHeader>
         <CardContent>
           <ImportGlossaryLink />
+        </CardContent>
+      </Card>
+
+      <Separator />
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-primary text-2xl">Replace Glossary</CardTitle>
+          <CardDescription className="text-base">
+            Upload a CSV file to completely replace the glossary. Every existing entry is deleted first, so download a
+            backup before you start.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ReplaceGlossaryLink />
         </CardContent>
       </Card>
     </div>

--- a/app/routes/_app.data.glossary._index.tsx
+++ b/app/routes/_app.data.glossary._index.tsx
@@ -19,20 +19,28 @@ export async function loader({ request }: LoaderFunctionArgs) {
   return null;
 }
 
-function DownloadGlossaryButton() {
+function DownloadGlossaryButton({
+  format,
+  label,
+  variant,
+}: {
+  format: 'csv' | 'xlsx';
+  label: string;
+  variant?: 'default' | 'secondary';
+}) {
   const [isDownloading, setIsDownloading] = useState(false);
   const { toast } = useToast();
 
   const handleDownload = async () => {
     setIsDownloading(true);
     try {
-      const response = await fetch('/data/glossary/download');
+      const response = await fetch(`/data/glossary/download?format=${format}`);
       if (!response.ok) throw new Error('Download failed');
       const blob = await response.blob();
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      a.download = 'glossary.csv';
+      a.download = format === 'csv' ? 'glossary.csv' : 'glossary.xlsx';
       a.click();
       URL.revokeObjectURL(url);
     } catch {
@@ -43,13 +51,13 @@ function DownloadGlossaryButton() {
   };
 
   return (
-    <Button onClick={handleDownload} disabled={isDownloading}>
+    <Button variant={variant} onClick={handleDownload} disabled={isDownloading}>
       {isDownloading ? (
         <Icons.Loader className="mr-2 h-4 w-4 animate-spin" />
       ) : (
         <Icons.Download className="mr-2 h-4 w-4" />
       )}
-      {isDownloading ? 'Preparing download…' : 'Download CSV'}
+      {isDownloading ? 'Preparing download…' : label}
     </Button>
   );
 }
@@ -100,10 +108,14 @@ export default function DataGlossary() {
         <Card>
           <CardHeader>
             <CardTitle className="text-primary text-2xl">Download Glossary</CardTitle>
-            <CardDescription className="text-base">Export the full glossary as a CSV file.</CardDescription>
+            <CardDescription className="text-base">
+              Export the full glossary as an Excel or CSV file. Either can be re-uploaded on the import and replace
+              pages.
+            </CardDescription>
           </CardHeader>
-          <CardContent>
-            <DownloadGlossaryButton />
+          <CardContent className="flex items-center gap-3">
+            <DownloadGlossaryButton format="xlsx" label="Download Excel" />
+            <DownloadGlossaryButton format="csv" variant="secondary" label="Download CSV" />
           </CardContent>
         </Card>
       )}

--- a/app/routes/_app.data.glossary._index.tsx
+++ b/app/routes/_app.data.glossary._index.tsx
@@ -1,10 +1,12 @@
 import type { LoaderFunctionArgs } from '@remix-run/node';
 
+import { useAbility } from '@casl/react';
 import { redirect } from '@remix-run/node';
 import { Link } from '@remix-run/react';
 import { useState } from 'react';
 
 import { assertAuthUser } from '~/auth.server';
+import { AbilityContext } from '~/authorisation';
 import { Icons } from '~/components/icons';
 import { Button } from '~/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '~/components/ui/card';
@@ -85,46 +87,63 @@ function ReplaceGlossaryLink() {
 }
 
 export default function DataGlossary() {
+  // Cosmetic only — each route gates itself server-side. These just avoid offering a card
+  // that would redirect on click.
+  const ability = useAbility(AbilityContext);
+  const canDownload = ability.can('Download', 'Glossary');
+  const canImport = ability.can('Create', 'Glossary');
+  const canReplace = ability.can('Delete', 'Glossary');
+
   return (
     <div className="container mx-auto max-w-5xl space-y-6 p-6">
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-primary text-2xl">Download Glossary</CardTitle>
-          <CardDescription className="text-base">Export the full glossary as a CSV file.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <DownloadGlossaryButton />
-        </CardContent>
-      </Card>
+      {canDownload && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-primary text-2xl">Download Glossary</CardTitle>
+            <CardDescription className="text-base">Export the full glossary as a CSV file.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <DownloadGlossaryButton />
+          </CardContent>
+        </Card>
+      )}
 
-      <Separator />
+      {canImport && (
+        <>
+          {canDownload && <Separator />}
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-primary text-2xl">Import Glossary</CardTitle>
-          <CardDescription className="text-base">
-            Upload a CSV file to bulk-import glossary entries. The file must match the downloaded format.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <ImportGlossaryLink />
-        </CardContent>
-      </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-primary text-2xl">Import Glossary</CardTitle>
+              <CardDescription className="text-base">
+                Upload a CSV file to bulk-import glossary entries. The file must match the downloaded format.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ImportGlossaryLink />
+            </CardContent>
+          </Card>
+        </>
+      )}
 
-      <Separator />
+      {canReplace && (
+        <>
+          <Separator />
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-primary text-2xl">Replace Glossary</CardTitle>
-          <CardDescription className="text-base">
-            Upload a CSV file to completely replace the glossary. Every existing entry is deleted first, so download a
-            backup before you start.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <ReplaceGlossaryLink />
-        </CardContent>
-      </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-primary text-2xl">Replace Glossary</CardTitle>
+              <CardDescription className="text-base">
+                Upload a CSV file to completely replace the glossary. Every existing entry is deleted first, so download
+                a backup before you start.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ReplaceGlossaryLink />
+            </CardContent>
+          </Card>
+        </>
+      )}
     </div>
   );
 }

--- a/app/routes/_app.data.glossary.download.ts
+++ b/app/routes/_app.data.glossary.download.ts
@@ -3,6 +3,7 @@ import type { LoaderFunctionArgs } from '@remix-run/node';
 import { redirect } from '@remix-run/node';
 
 import { assertAuthUser } from '~/auth.server';
+import { defineAbilityFor } from '~/authorisation';
 import { getAllGlossaries } from '~/services/glossary.service';
 
 function escapeCSVValue(value: unknown): string {
@@ -32,6 +33,9 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   const user = await assertAuthUser(request);
   if (!user) {
     return redirect('/login');
+  }
+  if (defineAbilityFor(user).cannot('Download', 'Glossary')) {
+    throw redirect('/data/glossary');
   }
   const glossaries = await getAllGlossaries();
   const reformedGlossaries = glossaries.reduce((acc, glossary) => {

--- a/app/routes/_app.data.glossary.download.ts
+++ b/app/routes/_app.data.glossary.download.ts
@@ -4,30 +4,8 @@ import { redirect } from '@remix-run/node';
 
 import { assertAuthUser } from '~/auth.server';
 import { defineAbilityFor } from '~/authorisation';
+import { glossaryDownloadResponse, parseExportFormat } from '~/services/glossary.export';
 import { getAllGlossaries } from '~/services/glossary.service';
-
-function escapeCSVValue(value: unknown): string {
-  if (value == null) return ''; // handle null or undefined
-
-  const str = String(value);
-
-  const shouldQuote = /[",\n]/.test(str);
-  const escaped = str.replace(/"/g, '""');
-
-  return shouldQuote ? `"${escaped}"` : escaped;
-}
-
-function generateCSV(data: Record<string, unknown>[]): string {
-  if (data.length === 0) return '';
-
-  const headers = Object.keys(data[0]);
-  const csvRows = [
-    headers.join(','), // Header row
-    ...data.map((row) => headers.map((header) => escapeCSVValue(row[header])).join(',')),
-  ];
-
-  return csvRows.join('\n');
-}
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const user = await assertAuthUser(request);
@@ -37,30 +15,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   if (defineAbilityFor(user).cannot('Download', 'Glossary')) {
     throw redirect('/data/glossary');
   }
+  const format = parseExportFormat(new URL(request.url).searchParams.get('format'));
   const glossaries = await getAllGlossaries();
-  const reformedGlossaries = glossaries.reduce((acc, glossary) => {
-    const { translations } = glossary;
-    const glossaries = translations?.map((translation) => ({
-      UUID: glossary.id,
-      ChineseTerm: glossary.glossary,
-      EnglishTerm: translation.glossary,
-      ChineseSutraText: translation.originSutraText,
-      EnglishSutraText: translation.targetSutraText,
-      SutraName: translation.sutraName,
-      Volume: translation.volume,
-      CBetaFrequency: glossary.cbetaFrequency,
-      Author: translation.author,
-      Phonetic: glossary.phonetic,
-    }));
-    // @ts-ignore
-    acc.push(...glossaries);
-    return acc;
-  }, []);
-  const csv = generateCSV(reformedGlossaries);
-  return new Response(csv, {
-    headers: {
-      'Content-Type': 'text/csv',
-      'Content-Disposition': 'attachment; filename="glossary.csv"',
-    },
-  });
+  return glossaryDownloadResponse(glossaries, format);
 };

--- a/app/routes/_app.data.glossary.import.tsx
+++ b/app/routes/_app.data.glossary.import.tsx
@@ -344,8 +344,8 @@ export default function GlossaryImportPage() {
   const currentChunkGroups = groups.slice(chunkIndex * CHUNK_SIZE, (chunkIndex + 1) * CHUNK_SIZE);
   // Merge grouped terms with per-chunk DB data for the comparison panel.
   const currentChunk: GlossaryGroup[] = currentChunkGroups.map((g) => {
-    const first = g.rows[0];
-    const existing = first.uuid ? (chunkExisting[first.uuid] ?? null) : (chunkExisting[first.chineseTerm] ?? null);
+    // Mirrors the server's match order in importGlossaries: id first, then term.
+    const existing = (g.uuid ? chunkExisting[g.uuid] : null) ?? chunkExisting[g.key] ?? null;
     return { ...g, existing };
   });
   const currentChunkRows = currentChunkGroups.flatMap((g) => g.rows);
@@ -395,8 +395,10 @@ export default function GlossaryImportPage() {
     const chunk = groups.slice(chunkIndex * CHUNK_SIZE, (chunkIndex + 1) * CHUNK_SIZE);
     if (chunk.length === 0) return;
 
-    const uuids = chunk.filter((g) => g.rows[0].uuid).map((g) => g.rows[0].uuid);
-    const terms = chunk.filter((g) => !g.rows[0].uuid).map((g) => g.rows[0].chineseTerm);
+    // Every group has a term; only some carry a UUID. Look both up — a group's id may be
+    // unknown to the database while its term already exists.
+    const uuids = chunk.map((g) => g.uuid).filter(Boolean);
+    const terms = chunk.map((g) => g.key);
 
     existingFetcherSubmit(
       { intent: 'fetch-existing', uuids: JSON.stringify(uuids), terms: JSON.stringify(terms) },

--- a/app/routes/_app.data.glossary.import.tsx
+++ b/app/routes/_app.data.glossary.import.tsx
@@ -6,6 +6,7 @@ import { AlertCircle, ArrowLeftRight, CheckCircle2, ChevronRight, FileText } fro
 import { useEffect, useRef, useState } from 'react';
 
 import { assertAuthUser } from '~/auth.server';
+import { defineAbilityFor } from '~/authorisation';
 import { Icons } from '~/components/icons';
 import { Alert, AlertDescription } from '~/components/ui/alert';
 import { Badge } from '~/components/ui/badge';
@@ -61,6 +62,9 @@ type ActionResponse =
 export async function loader({ request }: LoaderFunctionArgs) {
   const user = await assertAuthUser(request);
   if (!user) return redirect('/login');
+  // Import creates entries as well as updating them, so Create is the gate.
+  if (defineAbilityFor(user).cannot('Create', 'Glossary')) throw redirect('/data/glossary');
+
   return json({ userId: user.id });
 }
 
@@ -69,6 +73,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
 export async function action({ request }: ActionFunctionArgs) {
   const user = await assertAuthUser(request);
   if (!user) return redirect('/login');
+  // Covers both intents — fetch-existing reads glossary rows, import-chunk writes them.
+  if (defineAbilityFor(user).cannot('Create', 'Glossary')) {
+    return json<ActionResponse>({ intent: 'error', message: 'Not allowed.' }, { status: 403 });
+  }
 
   const formData = await request.formData();
   const intent = formData.get('intent') as string;

--- a/app/routes/_app.data.glossary.replace.tsx
+++ b/app/routes/_app.data.glossary.replace.tsx
@@ -259,6 +259,9 @@ export default function GlossaryReplacePage() {
   const totalGroups = groups.length;
   const totalChunks = Math.ceil(totalGroups / CHUNK_SIZE);
 
+  // A term whose rows carry more than one UUID is ambiguous — groupRows keeps the first.
+  const uuidConflicts = groups.filter((g) => g.uuidConflict);
+
   const currentChunkGroups = groups.slice(chunkIndex * CHUNK_SIZE, (chunkIndex + 1) * CHUNK_SIZE);
   const currentChunkRows = currentChunkGroups.flatMap((g) => g.rows);
   const remainingRows = groups.slice(chunkIndex * CHUNK_SIZE).flatMap((g) => g.rows);
@@ -427,6 +430,23 @@ export default function GlossaryReplacePage() {
         </CardContent>
       </Card>
 
+      {/* ── Ambiguous UUIDs in the uploaded file ── */}
+      {uuidConflicts.length > 0 && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>
+            {uuidConflicts.length} {uuidConflicts.length === 1 ? 'term carries' : 'terms carry'} more than one UUID in
+            this file (
+            {uuidConflicts
+              .slice(0, 5)
+              .map((g) => g.key)
+              .join('、')}
+            {uuidConflicts.length > 5 ? '…' : ''}). Each term can only be one entry, so the first UUID is kept and the
+            others are discarded. Fix the file if those ids matter.
+          </AlertDescription>
+        </Alert>
+      )}
+
       {/* ── Progress + Import All ── */}
       {totalGroups > 0 && (
         <div className="space-y-3 rounded-lg border p-4">
@@ -485,8 +505,8 @@ export default function GlossaryReplacePage() {
               </div>
               <div className="rounded-lg border p-4">
                 <p className="text-3xl font-bold text-amber-600 dark:text-amber-400">{totals.updated}</p>
-                <p className="text-foreground mt-1 text-sm font-medium">Merged</p>
-                <p className="text-muted-foreground text-xs">duplicate keys in file</p>
+                <p className="text-foreground mt-1 text-sm font-medium">Updated</p>
+                <p className="text-muted-foreground text-xs">already existed — expected 0</p>
               </div>
               <div className="rounded-lg border p-4">
                 <p className="text-destructive text-3xl font-bold">{totals.failed}</p>

--- a/app/routes/_app.data.glossary.replace.tsx
+++ b/app/routes/_app.data.glossary.replace.tsx
@@ -6,6 +6,7 @@ import { AlertCircle, CheckCircle2, ChevronRight, FileText } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react';
 
 import { assertAuthUser } from '~/auth.server';
+import { defineAbilityFor } from '~/authorisation';
 import { Icons } from '~/components/icons';
 import { Alert, AlertDescription } from '~/components/ui/alert';
 import { Button } from '~/components/ui/button';
@@ -33,6 +34,10 @@ type ActionResponse =
 export async function loader({ request }: LoaderFunctionArgs) {
   const user = await assertAuthUser(request);
   if (!user) return redirect('/login');
+  // Replacing the glossary is admin-only. The index page hides the link, but that's cosmetic —
+  // this check and the one in the action are what actually hold.
+  if (defineAbilityFor(user).cannot('Delete', 'Glossary')) throw redirect('/data/glossary');
+
   return json({ userId: user.id });
 }
 
@@ -41,6 +46,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
 export async function action({ request }: ActionFunctionArgs) {
   const user = await assertAuthUser(request);
   if (!user) return redirect('/login');
+  // The gate that matters: a non-admin POSTing here directly must not reach deleteAllGlossaries.
+  if (defineAbilityFor(user).cannot('Delete', 'Glossary')) {
+    return json<ActionResponse>({ intent: 'error', message: 'Not allowed.' }, { status: 403 });
+  }
 
   const formData = await request.formData();
   const intent = formData.get('intent') as string;

--- a/app/routes/_app.data.glossary.replace.tsx
+++ b/app/routes/_app.data.glossary.replace.tsx
@@ -2,13 +2,12 @@ import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
 
 import { json, redirect } from '@remix-run/node';
 import { Form, useActionData, useFetcher, useNavigation } from '@remix-run/react';
-import { AlertCircle, ArrowLeftRight, CheckCircle2, ChevronRight, FileText } from 'lucide-react';
+import { AlertCircle, CheckCircle2, ChevronRight, FileText } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import { assertAuthUser } from '~/auth.server';
 import { Icons } from '~/components/icons';
 import { Alert, AlertDescription } from '~/components/ui/alert';
-import { Badge } from '~/components/ui/badge';
 import { Button } from '~/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '~/components/ui/card';
 import { Separator } from '~/components/ui/separator';
@@ -21,38 +20,11 @@ import {
   type GlossaryImportRow,
   type GroupedTerm,
 } from '~/services/glossary.parse';
-import { getGlossariesByGivenGlossaries, importGlossaries, readGlossariesByIds } from '~/services/glossary.service';
+import { deleteAllGlossaries, importGlossaries } from '~/services/glossary.service';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-// Subset of ReadGlossary we need for display — avoids Date→string mismatch from Remix JSON serialization.
-type ExistingGlossary = {
-  id: string;
-  glossary: string;
-  phonetic?: string | null;
-  author?: string | null;
-  cbetaFrequency?: string | null;
-  discussion?: string | null;
-  translations?:
-    | Array<{
-        glossary: string;
-        language: string;
-        sutraName: string;
-        volume: string;
-        originSutraText?: string | null;
-        targetSutraText?: string | null;
-        author?: string | null;
-      }>
-    | null
-    | undefined;
-};
-
-type GlossaryGroup = GroupedTerm & {
-  existing: ExistingGlossary | null;
-};
-
 type ActionResponse =
-  | { intent: 'fetch-existing'; existing: Record<string, ExistingGlossary> }
   | { intent: 'import-chunk'; created: number; updated: number; failed: number }
   | { intent: 'error'; message: string };
 
@@ -73,26 +45,10 @@ export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData();
   const intent = formData.get('intent') as string;
 
-  // ── Fetch existing DB entries for a single chunk (bounded payload) ──
-  if (intent === 'fetch-existing') {
-    const uuids: string[] = JSON.parse((formData.get('uuids') as string) || '[]');
-    const terms: string[] = JSON.parse((formData.get('terms') as string) || '[]');
-
-    const [byUuid, byTerm] = await Promise.all([
-      uuids.length ? readGlossariesByIds(uuids) : Promise.resolve([]),
-      terms.length ? getGlossariesByGivenGlossaries(terms) : Promise.resolve([]),
-    ]);
-
-    const existing: Record<string, ExistingGlossary> = {};
-    for (const g of byUuid) existing[g.id] = g;
-    for (const g of byTerm) existing[g.glossary] = g;
-
-    return json<ActionResponse>({ intent: 'fetch-existing', existing });
-  }
-
-  // ── Import chunk: write a batch of rows to the database ──
+  // ── Import chunk: write a batch of rows, wiping the table first on the opening chunk ──
   if (intent === 'import-chunk') {
     const rowsJson = formData.get('rows') as string;
+    const wipe = formData.get('wipe') === 'true';
 
     if (!rowsJson) {
       return json<ActionResponse>({ intent: 'error', message: 'No rows provided.' }, { status: 400 });
@@ -100,6 +56,9 @@ export async function action({ request }: ActionFunctionArgs) {
 
     try {
       const rows: GlossaryImportRow[] = JSON.parse(rowsJson);
+      if (wipe) {
+        await deleteAllGlossaries();
+      }
       const result = await importGlossaries(rows, user.id);
       return json<ActionResponse>({ intent: 'import-chunk', ...result });
     } catch (e) {
@@ -113,65 +72,25 @@ export async function action({ request }: ActionFunctionArgs) {
 
 // ─── GlossaryTermCard ─────────────────────────────────────────────────────────
 
-type TermCardProps = {
-  group: GlossaryGroup;
-  variant: 'existing' | 'incoming';
-};
-
-function GlossaryTermCard({ group, variant }: TermCardProps) {
-  const isIncoming = variant === 'incoming';
-  const isNew = !group.existing;
+// There's no comparison panel here — the table is emptied first, so the only thing
+// worth showing is what the file is about to write.
+function GlossaryTermCard({ group }: { group: GroupedTerm }) {
   const first = group.rows[0];
+  const { chineseTerm, phonetic, author, cbetaFrequency } = first;
 
-  if (!isIncoming && !group.existing) {
-    return (
-      <div className="text-muted-foreground rounded-lg border border-dashed p-4 text-center text-sm">
-        No existing entry
-      </div>
-    );
-  }
-
-  const chineseTerm = isIncoming ? first.chineseTerm : group.existing!.glossary;
-  const phonetic = isIncoming ? first.phonetic : group.existing!.phonetic;
-  const author = isIncoming ? first.author : group.existing!.author;
-  const cbetaFrequency = isIncoming ? first.cbetaFrequency : group.existing!.cbetaFrequency;
-
-  const translations = isIncoming
-    ? group.rows
-        .filter((r) => r.englishTerm)
-        .map((r) => ({
-          glossary: r.englishTerm,
-          sutraName: r.sutraName,
-          volume: r.volume,
-          originSutraText: r.chineseSutraText || null,
-          targetSutraText: r.englishSutraText || null,
-        }))
-    : (group.existing?.translations ?? []).map((t) => ({
-        glossary: t.glossary,
-        sutraName: t.sutraName,
-        volume: t.volume,
-        originSutraText: t.originSutraText ?? null,
-        targetSutraText: t.targetSutraText ?? null,
-      }));
+  const translations = group.rows
+    .filter((r) => r.englishTerm)
+    .map((r) => ({
+      glossary: r.englishTerm,
+      sutraName: r.sutraName,
+      volume: r.volume,
+      originSutraText: r.chineseSutraText || null,
+      targetSutraText: r.englishSutraText || null,
+    }));
 
   return (
-    <div
-      className={`text-foreground space-y-2 rounded-lg border p-3 text-sm ${
-        isIncoming && isNew
-          ? 'border-green-200 bg-green-50 dark:border-green-900 dark:bg-green-950/30'
-          : isIncoming
-            ? 'border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-950/30'
-            : 'bg-muted/30'
-      }`}
-    >
-      <div className="flex items-start justify-between gap-2">
-        <span className="text-base leading-tight font-semibold">{chineseTerm}</span>
-        {isIncoming && (
-          <Badge className="shrink-0 text-xs" variant={isNew ? 'default' : 'secondary'}>
-            {isNew ? 'New' : 'Update'}
-          </Badge>
-        )}
-      </div>
+    <div className="text-foreground space-y-2 rounded-lg border p-3 text-sm">
+      <span className="text-base leading-tight font-semibold">{chineseTerm}</span>
 
       {(phonetic || author || cbetaFrequency) && (
         <div className="text-muted-foreground space-y-0.5 text-xs">
@@ -205,15 +124,15 @@ function GlossaryTermCard({ group, variant }: TermCardProps) {
   );
 }
 
-// ─── ImportInstructions ───────────────────────────────────────────────────────
+// ─── ReplaceInstructions ──────────────────────────────────────────────────────
 
-function ImportInstructions() {
+function ReplaceInstructions() {
   return (
     <Card className="mt-6">
       <CardHeader>
         <CardTitle className="text-primary flex items-center gap-2 text-lg">
           <FileText className="h-4 w-4" />
-          File Format &amp; Import Instructions
+          File Format &amp; Replace Instructions
         </CardTitle>
       </CardHeader>
       <CardContent className="text-muted-foreground space-y-4 text-sm">
@@ -221,14 +140,13 @@ function ImportInstructions() {
           <p className="text-foreground mb-1 font-medium">CSV / XLSX columns (header row required)</p>
           <ul className="ml-4 list-disc space-y-0.5">
             <li>
-              <code>UUID</code> — optional; links a row to an existing database entry (use the downloaded export to
-              preserve IDs)
+              <code>UUID</code> — optional; groups rows into one entry and preserves the entry&apos;s ID
             </li>
             <li>
               <code>ChineseTerm</code> — <strong>required</strong>; the primary glossary entry
             </li>
             <li>
-              <code>EnglishTerm</code> — English translation; rows without this field are used only for metadata updates
+              <code>EnglishTerm</code> — English translation; rows without this field contribute metadata only
             </li>
             <li>
               <code>Phonetic</code> — pronunciation guide (applies to the whole entry)
@@ -253,7 +171,7 @@ function ImportInstructions() {
             </li>
           </ul>
           <p className="mt-2">
-            Multiple CSV rows sharing the same UUID or Chinese term are merged into one glossary entry with multiple
+            Multiple rows sharing the same UUID or Chinese term are merged into one glossary entry with multiple
             translations.
           </p>
         </div>
@@ -261,7 +179,7 @@ function ImportInstructions() {
         <Separator />
 
         <div>
-          <p className="text-foreground mb-1 font-medium">Chunked import process</p>
+          <p className="text-foreground mb-1 font-medium">Chunked replace process</p>
           <ol className="ml-4 list-decimal space-y-1">
             <li>
               <strong>Upload</strong> — select your CSV or XLSX file and click <em>Preview</em>. Both file types are
@@ -270,20 +188,20 @@ function ImportInstructions() {
             </li>
             <li>
               <strong>Chunk display</strong> — the file is divided into chunks of{' '}
-              <strong>{CHUNK_SIZE} glossary terms</strong> (not rows). Each term may span several CSV rows when it has
+              <strong>{CHUNK_SIZE} glossary terms</strong> (not rows). Each term may span several rows when it has
               multiple translations.
             </li>
             <li>
-              <strong>Review</strong> — the left column shows what is currently in the database; the right column shows
-              what the CSV will create or overwrite. Green cards are new entries; amber cards are updates.
+              <strong>Review</strong> — each chunk lists the entries it will write. There is no side-by-side comparison,
+              because the existing glossary is discarded rather than merged.
             </li>
             <li>
-              <strong>Import Chunk</strong> — click the button to write the current chunk to the database, then the next
-              chunk is shown automatically.
+              <strong>Import Chunk</strong> — writes the current chunk and advances. The first write deletes every
+              existing glossary entry before inserting.
             </li>
             <li>
-              <strong>Repeat</strong> until all chunks are imported. The progress bar at the top tracks how far along
-              you are.
+              <strong>Repeat</strong> until all chunks are written. The progress bar at the top tracks how far along you
+              are.
             </li>
           </ol>
         </div>
@@ -291,12 +209,16 @@ function ImportInstructions() {
         <Separator />
 
         <div>
-          <p className="text-foreground mb-1 font-medium">Conflict resolution</p>
+          <p className="text-foreground mb-1 font-medium">Replacing existing data</p>
           <p>
-            Rows with a UUID are matched to the existing record by primary key. Rows without a UUID are matched by
-            Chinese term. When a match is found the entry&apos;s metadata (phonetic, author, CBETA frequency) and its
-            full translations list are <strong>replaced</strong> with the CSV values. New entries are created and
-            indexed in Algolia automatically.
+            Starting the import <strong>permanently deletes every existing glossary entry</strong>, then writes the
+            file&apos;s entries as new records. There is no per-row matching or merging against current data — the file
+            becomes the complete glossary. New entries are indexed in Algolia automatically.
+          </p>
+          <p className="mt-2">
+            The wipe happens as part of the first chunk&apos;s write, and the remaining chunks are separate requests. If
+            you stop partway the glossary will contain only the chunks written so far, so{' '}
+            <strong>download a CSV backup before you start</strong>.
           </p>
         </div>
       </CardContent>
@@ -308,14 +230,13 @@ function ImportInstructions() {
 
 type ChunkResult = { created: number; updated: number; failed: number };
 
-export default function GlossaryImportPage() {
+const WIPE_CONFIRM = 'This permanently deletes all existing glossary entries before importing. Continue?';
+
+export default function GlossaryReplacePage() {
   const actionData = useActionData<ActionResponse>();
   const navigation = useNavigation();
   const isSubmitting = navigation.state === 'submitting';
   const navigationIntent = navigation.formData?.get('intent') as string | null;
-
-  // Per-chunk DB lookups — keeps payloads bounded to CHUNK_SIZE entries.
-  const existingFetcher = useFetcher<ActionResponse>();
 
   const autoFetcher = useFetcher<ActionResponse>();
   const autoQueueRef = useRef<GlossaryImportRow[][]>([]);
@@ -326,11 +247,9 @@ export default function GlossaryImportPage() {
   const [isParsing, setIsParsing] = useState(false);
   const [parseError, setParseError] = useState<string | null>(null);
 
-  // groups holds parsed-and-grouped data without DB entries (avoids large server payloads).
+  // groups holds parsed-and-grouped data (avoids large server payloads — only chunks are posted).
   const [groups, setGroups] = useState<GroupedTerm[]>([]);
   const [totalRows, setTotalRows] = useState(0);
-  // Existing DB entries for the currently displayed chunk only.
-  const [chunkExisting, setChunkExisting] = useState<Record<string, ExistingGlossary>>({});
 
   const [chunkIndex, setChunkIndex] = useState(0);
   const [chunkResults, setChunkResults] = useState<ChunkResult[]>([]);
@@ -338,20 +257,15 @@ export default function GlossaryImportPage() {
   const [isAutoImporting, setIsAutoImporting] = useState(false);
 
   const totalGroups = groups.length;
-  const totalCsvRows = totalRows;
   const totalChunks = Math.ceil(totalGroups / CHUNK_SIZE);
 
   const currentChunkGroups = groups.slice(chunkIndex * CHUNK_SIZE, (chunkIndex + 1) * CHUNK_SIZE);
-  // Merge grouped terms with per-chunk DB data for the comparison panel.
-  const currentChunk: GlossaryGroup[] = currentChunkGroups.map((g) => {
-    const first = g.rows[0];
-    const existing = first.uuid ? (chunkExisting[first.uuid] ?? null) : (chunkExisting[first.chineseTerm] ?? null);
-    return { ...g, existing };
-  });
   const currentChunkRows = currentChunkGroups.flatMap((g) => g.rows);
   const remainingRows = groups.slice(chunkIndex * CHUNK_SIZE).flatMap((g) => g.rows);
   const isAllDone = isFullyImported || (totalChunks > 0 && chunkIndex >= totalChunks);
-  const isLoadingExisting = existingFetcher.state !== 'idle';
+
+  // Only the opening write of a run wipes; every later chunk appends to it.
+  const isFirstChunk = chunkIndex === 0 && chunkResults.length === 0;
 
   const totals = chunkResults.reduce(
     (acc, r) => ({ created: acc.created + r.created, updated: acc.updated + r.updated, failed: acc.failed + r.failed }),
@@ -361,7 +275,6 @@ export default function GlossaryImportPage() {
   const resetState = () => {
     setGroups([]);
     setTotalRows(0);
-    setChunkExisting({});
     setChunkIndex(0);
     setChunkResults([]);
     setIsFullyImported(false);
@@ -388,30 +301,7 @@ export default function GlossaryImportPage() {
     }
   };
 
-  // ── Fetch DB entries for the current chunk whenever groups or chunkIndex changes ──
-  const existingFetcherSubmit = existingFetcher.submit;
-  useEffect(() => {
-    if (groups.length === 0 || isAutoImporting) return;
-    const chunk = groups.slice(chunkIndex * CHUNK_SIZE, (chunkIndex + 1) * CHUNK_SIZE);
-    if (chunk.length === 0) return;
-
-    const uuids = chunk.filter((g) => g.rows[0].uuid).map((g) => g.rows[0].uuid);
-    const terms = chunk.filter((g) => !g.rows[0].uuid).map((g) => g.rows[0].chineseTerm);
-
-    existingFetcherSubmit(
-      { intent: 'fetch-existing', uuids: JSON.stringify(uuids), terms: JSON.stringify(terms) },
-      { method: 'post' },
-    );
-  }, [groups, chunkIndex, isAutoImporting, existingFetcherSubmit]);
-
-  // ── Update chunkExisting when fetch-existing returns ──
-  useEffect(() => {
-    if (existingFetcher.data?.intent === 'fetch-existing') {
-      setChunkExisting(existingFetcher.data.existing);
-    }
-  }, [existingFetcher.data]);
-
-  // ── Manual chunk-by-chunk imports ──
+  // ── Manual chunk-by-chunk imports (via <Form> + useActionData) ──
   useEffect(() => {
     if (actionData?.intent === 'import-chunk') {
       setChunkResults((prev) => [
@@ -429,6 +319,8 @@ export default function GlossaryImportPage() {
 
   // ── Auto-import: submit one chunk at a time via fetcher ──
   const handleImportAll = () => {
+    if (isFirstChunk && !window.confirm(WIPE_CONFIRM)) return;
+
     const queue = chunkGroupsToRows(groups.slice(chunkIndex * CHUNK_SIZE));
     if (queue.length === 0) return;
 
@@ -439,6 +331,7 @@ export default function GlossaryImportPage() {
     const formData = new FormData();
     formData.set('intent', 'import-chunk');
     formData.set('rows', JSON.stringify(queue[0]));
+    formData.set('wipe', isFirstChunk ? 'true' : 'false');
     autoFetcher.submit(formData, { method: 'post' });
   };
 
@@ -461,9 +354,11 @@ export default function GlossaryImportPage() {
       setIsAutoImporting(false);
       setIsFullyImported(true);
     } else {
+      // The wipe already happened on the opening chunk — follow-ups only append.
       const formData = new FormData();
       formData.set('intent', 'import-chunk');
       formData.set('rows', JSON.stringify(nextQueue[0]));
+      formData.set('wipe', 'false');
       autoFetcher.submit(formData, { method: 'post' });
     }
   }, [isAutoImporting, autoFetcher.state, autoFetcher.data, autoFetcher]);
@@ -475,15 +370,24 @@ export default function GlossaryImportPage() {
       {/* ── File upload ── */}
       <Card>
         <CardHeader>
-          <CardTitle className="text-primary text-2xl">Import Glossary</CardTitle>
+          <CardTitle className="text-primary text-2xl">Replace Glossary</CardTitle>
           <CardDescription className="text-base">
-            Upload a CSV or XLSX file to review and import glossary entries in chunks of {CHUNK_SIZE} terms at a time.
+            Upload a CSV or XLSX file to replace the entire glossary. The first write clears all existing entries, then
+            the file is imported in chunks of {CHUNK_SIZE} terms at a time.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription>
+              Starting the import permanently deletes every existing glossary entry before writing the file. This cannot
+              be undone — download a CSV backup first.
+            </AlertDescription>
+          </Alert>
+
           <div className="flex items-center gap-3">
             <label
-              htmlFor="glossary-import-file"
+              htmlFor="glossary-replace-file"
               className="hover:bg-accent text-foreground flex cursor-pointer items-center gap-2 rounded-md border px-4 py-2 text-sm font-medium"
             >
               <Icons.Add className="h-4 w-4" />
@@ -494,7 +398,7 @@ export default function GlossaryImportPage() {
               name="file"
               className="sr-only"
               accept=".csv,.xlsx,.xls"
-              id="glossary-import-file"
+              id="glossary-replace-file"
               onChange={(e) => {
                 const file = e.target.files?.[0] ?? null;
                 setSelectedFile(file);
@@ -528,10 +432,10 @@ export default function GlossaryImportPage() {
         <div className="space-y-3 rounded-lg border p-4">
           <div className="flex items-center justify-between text-sm">
             <span className="text-foreground font-medium">
-              {isAllDone ? 'Import complete' : `Chunk ${chunkIndex + 1} of ${totalChunks}`}
+              {isAllDone ? 'Replace complete' : `Chunk ${chunkIndex + 1} of ${totalChunks}`}
             </span>
             <span className="text-muted-foreground">
-              {totalGroups} terms &middot; {totalCsvRows} CSV rows
+              {totalGroups} terms &middot; {totalRows} rows
             </span>
           </div>
           <div className="bg-muted h-2 w-full overflow-hidden rounded-full">
@@ -560,16 +464,16 @@ export default function GlossaryImportPage() {
         </div>
       )}
 
-      {/* ── Stats card (shown once any imports have run) ── */}
+      {/* ── Stats card (shown once the replace finishes) ── */}
       {isAllDone && (
         <Card>
           <CardHeader className="pb-3">
             <CardTitle className="text-primary flex items-center gap-2 text-lg">
               <CheckCircle2 className="h-5 w-5" />
-              Import Complete
+              Replace Complete
             </CardTitle>
             <CardDescription>
-              {totalGroups} terms from file &middot; {totalCsvRows} CSV rows processed
+              {totalGroups} terms from file &middot; {totalRows} rows written
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -581,8 +485,8 @@ export default function GlossaryImportPage() {
               </div>
               <div className="rounded-lg border p-4">
                 <p className="text-3xl font-bold text-amber-600 dark:text-amber-400">{totals.updated}</p>
-                <p className="text-foreground mt-1 text-sm font-medium">Updated</p>
-                <p className="text-muted-foreground text-xs">existing entries overwritten</p>
+                <p className="text-foreground mt-1 text-sm font-medium">Merged</p>
+                <p className="text-muted-foreground text-xs">duplicate keys in file</p>
               </div>
               <div className="rounded-lg border p-4">
                 <p className="text-destructive text-3xl font-bold">{totals.failed}</p>
@@ -594,54 +498,26 @@ export default function GlossaryImportPage() {
         </Card>
       )}
 
-      {/* ── Comparison panel ── */}
-      {totalGroups > 0 && !isAllDone && currentChunk.length > 0 && (
+      {/* ── Incoming entries preview ── */}
+      {totalGroups > 0 && !isAllDone && currentChunkGroups.length > 0 && (
         <Card>
           <CardHeader>
             <CardTitle className="text-primary flex items-center gap-2 text-xl">
-              <ArrowLeftRight className="h-5 w-5" />
+              <FileText className="h-5 w-5" />
               Chunk {chunkIndex + 1} of {totalChunks}
             </CardTitle>
             <CardDescription className="text-base">
-              Reviewing {currentChunk.length} {currentChunk.length === 1 ? 'term' : 'terms'} ({currentChunkRows.length}{' '}
-              CSV {currentChunkRows.length === 1 ? 'row' : 'rows'}). Upload a new file above to start over.
+              Writing {currentChunkGroups.length} {currentChunkGroups.length === 1 ? 'term' : 'terms'} (
+              {currentChunkRows.length} {currentChunkRows.length === 1 ? 'row' : 'rows'}). Upload a new file above to
+              start over.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-6">
-            {isLoadingExisting ? (
-              <div className="text-muted-foreground flex items-center justify-center gap-2 py-8 text-sm">
-                <Icons.Loader className="h-4 w-4 animate-spin" />
-                Loading comparison data…
-              </div>
-            ) : (
-              <div className="grid grid-cols-2 gap-4">
-                {/* Left: current database state */}
-                <div>
-                  <h4 className="text-primary mb-3 text-base font-medium">Current Database</h4>
-                  <div className="space-y-2">
-                    {currentChunk.map((group) => (
-                      <GlossaryTermCard group={group} key={group.key} variant="existing" />
-                    ))}
-                  </div>
-                </div>
-
-                {/* Right: incoming from file */}
-                <div>
-                  <h4 className="text-primary mb-3 text-base font-medium">
-                    Incoming from File{' '}
-                    <span className="text-muted-foreground text-sm font-normal">
-                      ({currentChunk.filter((g) => !g.existing).length} new,{' '}
-                      {currentChunk.filter((g) => g.existing).length} updates)
-                    </span>
-                  </h4>
-                  <div className="space-y-2">
-                    {currentChunk.map((group) => (
-                      <GlossaryTermCard group={group} key={group.key} variant="incoming" />
-                    ))}
-                  </div>
-                </div>
-              </div>
-            )}
+            <div className="space-y-2">
+              {currentChunkGroups.map((group) => (
+                <GlossaryTermCard group={group} key={group.key} />
+              ))}
+            </div>
 
             <Separator />
 
@@ -655,8 +531,14 @@ export default function GlossaryImportPage() {
                   Import All
                 </Button>
               )}
-              <Form method="post">
+              <Form
+                method="post"
+                onSubmit={(e) => {
+                  if (isFirstChunk && !window.confirm(WIPE_CONFIRM)) e.preventDefault();
+                }}
+              >
                 <input type="hidden" name="intent" value="import-chunk" />
+                <input name="wipe" type="hidden" value={isFirstChunk ? 'true' : 'false'} />
                 <input name="rows" type="hidden" value={JSON.stringify(currentChunkRows)} />
                 <Button type="submit" disabled={isSubmitting} className="flex items-center gap-2">
                   {isSubmitting && navigationIntent === 'import-chunk' ? (
@@ -677,7 +559,7 @@ export default function GlossaryImportPage() {
         </Card>
       )}
 
-      <ImportInstructions />
+      <ReplaceInstructions />
     </div>
   );
 }

--- a/app/routes/_app.data.tsx
+++ b/app/routes/_app.data.tsx
@@ -3,6 +3,7 @@ import type { LoaderFunctionArgs, MetaFunction } from '@vercel/remix';
 import { json, Outlet, redirect, useLoaderData, useLocation } from '@remix-run/react';
 
 import { assertAuthUser } from '~/auth.server';
+import { defineAbilityFor } from '~/authorisation';
 import { SideBarTrigger } from '~/components/SideBarTrigger';
 import { Separator } from '~/components/ui/separator';
 import { Toaster } from '~/components/ui/toaster';
@@ -23,6 +24,11 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   const user = await assertAuthUser(request);
   if (!user) {
     return redirect('/login');
+  }
+  // Guards every /data/* route in one place, and makes the sidebar hiding this menu meaningful
+  // rather than cosmetic. Individual routes still gate their own specific actions on top.
+  if (defineAbilityFor(user).cannot('Read', 'DataManagement')) {
+    throw redirect('/dashboard');
   }
   const allUsers = await readUsers();
   return json({

--- a/app/routes/_app.glossary.download.ts
+++ b/app/routes/_app.glossary.download.ts
@@ -4,30 +4,8 @@ import { redirect } from '@remix-run/node';
 
 import { assertAuthUser } from '~/auth.server';
 import { defineAbilityFor } from '~/authorisation';
+import { glossaryDownloadResponse, parseExportFormat } from '~/services/glossary.export';
 import { getAllGlossaries } from '~/services/glossary.service';
-
-function escapeCSVValue(value: unknown): string {
-  if (value == null) return ''; // handle null or undefined
-
-  const str = String(value);
-
-  const shouldQuote = /[",\n]/.test(str);
-  const escaped = str.replace(/"/g, '""');
-
-  return shouldQuote ? `"${escaped}"` : escaped;
-}
-
-function generateCSV(data: Record<string, unknown>[]): string {
-  if (data.length === 0) return '';
-
-  const headers = Object.keys(data[0]);
-  const csvRows = [
-    headers.join(','), // Header row
-    ...data.map((row) => headers.map((header) => escapeCSVValue(row[header])).join(',')),
-  ];
-
-  return csvRows.join('\n');
-}
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const user = await assertAuthUser(request);
@@ -39,30 +17,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   if (defineAbilityFor(user).cannot('Download', 'Glossary')) {
     throw redirect('/glossary');
   }
+  const format = parseExportFormat(new URL(request.url).searchParams.get('format'));
   const glossaries = await getAllGlossaries();
-  const reformedGlossaries = glossaries.reduce((acc, glossary) => {
-    const { translations } = glossary;
-    const glossaries = translations?.map((translation) => ({
-      UUID: glossary.id,
-      ChineseTerm: glossary.glossary,
-      EnglishTerm: translation.glossary,
-      ChineseSutraText: translation.originSutraText,
-      EnglishSutraText: translation.targetSutraText,
-      SutraName: translation.sutraName,
-      Volume: translation.volume,
-      CBetaFrequency: glossary.cbetaFrequency,
-      Author: translation.author,
-      Phonetic: glossary.phonetic,
-    }));
-    // @ts-ignore
-    acc.push(...glossaries);
-    return acc;
-  }, []);
-  const csv = generateCSV(reformedGlossaries);
-  return new Response(csv, {
-    headers: {
-      'Content-Type': 'text/csv',
-      'Content-Disposition': 'attachment; filename="glossary.csv"',
-    },
-  });
+  return glossaryDownloadResponse(glossaries, format);
 };

--- a/app/routes/_app.glossary.download.ts
+++ b/app/routes/_app.glossary.download.ts
@@ -3,6 +3,7 @@ import type { LoaderFunctionArgs } from '@remix-run/node';
 import { redirect } from '@remix-run/node';
 
 import { assertAuthUser } from '~/auth.server';
+import { defineAbilityFor } from '~/authorisation';
 import { getAllGlossaries } from '~/services/glossary.service';
 
 function escapeCSVValue(value: unknown): string {
@@ -32,6 +33,11 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   const user = await assertAuthUser(request);
   if (!user) {
     return redirect('/login');
+  }
+  // The <Can I="Download" this="Glossary"> wrapper on the icon only hides the link; this is
+  // what stops a direct request for the full export.
+  if (defineAbilityFor(user).cannot('Download', 'Glossary')) {
+    throw redirect('/glossary');
   }
   const glossaries = await getAllGlossaries();
   const reformedGlossaries = glossaries.reduce((acc, glossary) => {

--- a/app/routes/_app.glossary.tsx
+++ b/app/routes/_app.glossary.tsx
@@ -97,7 +97,7 @@ export default function GlossaryLayout() {
           </div>
           <div className="flex items-center gap-2">
             <Can I="Download" this="Glossary">
-              <Link reloadDocument to="/glossary/download" download="glossary.csv">
+              <Link reloadDocument to="/glossary/download" download="glossary.xlsx">
                 <Icons.Download className="h-6 w-6 text-slate-800" />
               </Link>
             </Can>

--- a/app/routes/_app.tsx
+++ b/app/routes/_app.tsx
@@ -12,7 +12,6 @@ import { ErrorInfo } from '~/components/ErrorInfo';
 import { SearchProvider } from '~/components/SearchContext';
 import { SideBarMenu } from '~/components/SideBarMenu';
 import { SideBarMenuContextProvider } from '~/components/SideBarMenuContext';
-import { type ReadUser } from '~/drizzle/schema';
 import { readActiveNotifications } from '~/services/notification.service';
 import { readUsers } from '~/services/user.service';
 
@@ -59,7 +58,7 @@ export default function AppLayout() {
     return <Outlet />;
   }
 
-  const ability = defineAbilityFor(user as unknown as ReadUser);
+  const ability = defineAbilityFor(user);
 
   const handleDismiss = async (notificationId: string) => {
     fetcher.submit({ notificationId, kind: 'dismiss-notification' }, { method: 'POST', action: '/admin?index' });
@@ -73,7 +72,7 @@ export default function AppLayout() {
             <BannerStack banners={notifications} onDismiss={handleDismiss} />
             <div className="flex h-screen">
               <SideBarMenu avatarSrc={avatar} userRole={user.role} userEmail={user.email} userName={user.username} />
-              <main className="flex-1 overflow-y-auto bg-secondary">
+              <main className="bg-secondary flex-1 overflow-y-auto">
                 <Outlet />
               </main>
             </div>

--- a/app/services/glossary.export.ts
+++ b/app/services/glossary.export.ts
@@ -1,0 +1,112 @@
+import { type ReadGlossary } from '~/drizzle/tables';
+
+// Column order and names must match what the import parser reads (see XLSX_COLUMNS /
+// parseGlossaryCSV in glossary.parse.ts), so a downloaded file round-trips back through import.
+export const GLOSSARY_EXPORT_HEADERS = [
+  'UUID',
+  'ChineseTerm',
+  'EnglishTerm',
+  'ChineseSutraText',
+  'EnglishSutraText',
+  'SutraName',
+  'Volume',
+  'CBetaFrequency',
+  'Author',
+  'Phonetic',
+] as const;
+
+export type GlossaryExportRow = Record<(typeof GLOSSARY_EXPORT_HEADERS)[number], string>;
+
+export type GlossaryExportFormat = 'csv' | 'xlsx';
+
+// Flattens each entry to one row per translation. An entry with no translations contributes no
+// rows — matching the original CSV export, and the fact that a term without an EnglishTerm has
+// nothing to export.
+export function glossariesToExportRows(glossaries: ReadGlossary[]): GlossaryExportRow[] {
+  return glossaries.flatMap((glossary) =>
+    (glossary.translations ?? []).map((t) => ({
+      UUID: glossary.id ?? '',
+      ChineseTerm: glossary.glossary ?? '',
+      EnglishTerm: t.glossary ?? '',
+      ChineseSutraText: t.originSutraText ?? '',
+      EnglishSutraText: t.targetSutraText ?? '',
+      SutraName: t.sutraName ?? '',
+      Volume: t.volume ?? '',
+      CBetaFrequency: glossary.cbetaFrequency ?? '',
+      Author: t.author ?? '',
+      Phonetic: glossary.phonetic ?? '',
+    })),
+  );
+}
+
+// ─── CSV ──────────────────────────────────────────────────────────────────────
+
+function escapeCSVValue(value: string): string {
+  const shouldQuote = /[",\n]/.test(value);
+  const escaped = value.replace(/"/g, '""');
+  return shouldQuote ? `"${escaped}"` : escaped;
+}
+
+export function glossariesToCSV(glossaries: ReadGlossary[]): string {
+  const rows = glossariesToExportRows(glossaries);
+  // Headers come from the fixed column list rather than the first row, so an empty glossary
+  // still produces a valid, importable header line.
+  const lines = [
+    GLOSSARY_EXPORT_HEADERS.join(','),
+    ...rows.map((row) => GLOSSARY_EXPORT_HEADERS.map((header) => escapeCSVValue(row[header])).join(',')),
+  ];
+  return lines.join('\n');
+}
+
+// ─── XLSX ─────────────────────────────────────────────────────────────────────
+
+// Builds an .xlsx workbook as bytes. SheetJS is dynamically imported so this module carries no
+// static dependency on it — only the download loaders that call this pull it in, on the server.
+export async function glossariesToXLSX(glossaries: ReadGlossary[]): Promise<Uint8Array> {
+  const { utils, write } = await import('xlsx');
+
+  const rows = glossariesToExportRows(glossaries);
+  // Array-of-arrays keeps the column order fixed and preserves the header row even when there
+  // are no data rows, so an empty glossary still exports a valid, importable file.
+  const aoa: string[][] = [
+    [...GLOSSARY_EXPORT_HEADERS],
+    ...rows.map((row) => GLOSSARY_EXPORT_HEADERS.map((header) => row[header])),
+  ];
+
+  const worksheet = utils.aoa_to_sheet(aoa);
+  const workbook = utils.book_new();
+  utils.book_append_sheet(workbook, worksheet, 'Glossary');
+
+  return write(workbook, { type: 'array', bookType: 'xlsx' }) as Uint8Array;
+}
+
+// ─── Response ───────────────────────────────────────────────────────────────
+
+const CONTENT_TYPES: Record<GlossaryExportFormat, string> = {
+  csv: 'text/csv',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+};
+
+const FILENAMES: Record<GlossaryExportFormat, string> = {
+  csv: 'glossary.csv',
+  xlsx: 'glossary.xlsx',
+};
+
+// Excel is the default; only an explicit ?format=csv opts out. Anything else falls back to xlsx.
+export function parseExportFormat(value: string | null | undefined): GlossaryExportFormat {
+  return value === 'csv' ? 'csv' : 'xlsx';
+}
+
+// Shared Response so both download routes agree on content type, filename and body per format.
+export async function glossaryDownloadResponse(
+  glossaries: ReadGlossary[],
+  format: GlossaryExportFormat,
+): Promise<Response> {
+  const body = format === 'csv' ? glossariesToCSV(glossaries) : await glossariesToXLSX(glossaries);
+  return new Response(body, {
+    headers: {
+      'Content-Type': CONTENT_TYPES[format],
+      'Content-Disposition': `attachment; filename="${FILENAMES[format]}"`,
+    },
+  });
+}

--- a/app/services/glossary.parse.ts
+++ b/app/services/glossary.parse.ts
@@ -1,0 +1,162 @@
+import Papa from 'papaparse';
+
+// Client-safe glossary file parsing.
+//
+// This module is imported by browser event handlers (the Preview button on the
+// import/replace routes), so it must never reach into `~/lib/db.server`, Algolia
+// or OpenAI — doing so would drag a `.server` module into the client bundle.
+// Server-side glossary work lives in `glossary.service.ts`.
+
+// Number of glossary terms (not rows) written per chunk.
+export const CHUNK_SIZE = 15;
+
+export type GlossaryImportRow = {
+  uuid: string;
+  chineseTerm: string;
+  englishTerm: string;
+  chineseSutraText: string;
+  englishSutraText: string;
+  sutraName: string;
+  volume: string;
+  cbetaFrequency: string;
+  author: string;
+  phonetic: string;
+};
+
+export type GroupedTerm = {
+  key: string;
+  rows: GlossaryImportRow[];
+};
+
+// Thrown for problems we can explain to the user; anything else is an unexpected parse failure.
+export class GlossaryParseError extends Error {}
+
+// Maps lowercase header variants to canonical GlossaryImportRow field names.
+const XLSX_COLUMNS: Record<string, keyof GlossaryImportRow> = {
+  uuid: 'uuid',
+  chineseterm: 'chineseTerm',
+  'chinese term': 'chineseTerm',
+  englishterm: 'englishTerm',
+  'english term': 'englishTerm',
+  chinesesutratext: 'chineseSutraText',
+  'chinese sutra text': 'chineseSutraText',
+  englishsutratext: 'englishSutraText',
+  'english sutra text': 'englishSutraText',
+  sutraname: 'sutraName',
+  'sutra name': 'sutraName',
+  volume: 'volume',
+  cbetafrequency: 'cbetaFrequency',
+  'cbeta frequency': 'cbetaFrequency',
+  author: 'author',
+  phonetic: 'phonetic',
+};
+
+// PapaParse is isomorphic — safe to call in browser event handlers.
+export function parseGlossaryCSV(csvText: string): GlossaryImportRow[] {
+  const result = Papa.parse<Record<string, string>>(csvText, {
+    header: true,
+    skipEmptyLines: true,
+  });
+  return result.data
+    .filter((row) => row.ChineseTerm?.trim())
+    .map((row) => ({
+      uuid: row.UUID?.trim() ?? '',
+      chineseTerm: row.ChineseTerm?.trim() ?? '',
+      englishTerm: row.EnglishTerm?.trim() ?? '',
+      chineseSutraText: row.ChineseSutraText?.trim() ?? '',
+      englishSutraText: row.EnglishSutraText?.trim() ?? '',
+      sutraName: row.SutraName?.trim() ?? '',
+      volume: row.Volume?.trim() ?? '',
+      cbetaFrequency: row.CBetaFrequency?.trim() ?? '',
+      author: row.Author?.trim() ?? '',
+      phonetic: row.Phonetic?.trim() ?? '',
+    }));
+}
+
+// SheetJS is dynamically imported so it's only bundled when the user actually clicks Preview on an XLSX.
+export async function parseGlossaryXLSX(file: File): Promise<GlossaryImportRow[]> {
+  const { read, utils } = await import('xlsx');
+  const arrayBuffer = await file.arrayBuffer();
+  const workbook = read(new Uint8Array(arrayBuffer), { type: 'array' });
+  const worksheet = workbook.Sheets[workbook.SheetNames[0]];
+  if (!worksheet) return [];
+
+  // aoa[0] = header row; aoa[1..] = data rows.
+  const aoa = utils.sheet_to_json<string[]>(worksheet, { header: 1, defval: '', raw: false });
+  if (aoa.length === 0) return [];
+
+  const colMap: Record<number, keyof GlossaryImportRow> = {};
+  aoa[0].forEach((header, idx) => {
+    const field =
+      XLSX_COLUMNS[
+        String(header ?? '')
+          .trim()
+          .toLowerCase()
+      ];
+    if (field) colMap[idx] = field;
+  });
+
+  return aoa
+    .slice(1)
+    .map((row) => {
+      const entry: GlossaryImportRow = {
+        uuid: '',
+        chineseTerm: '',
+        englishTerm: '',
+        chineseSutraText: '',
+        englishSutraText: '',
+        sutraName: '',
+        volume: '',
+        cbetaFrequency: '',
+        author: '',
+        phonetic: '',
+      };
+      Object.entries(colMap).forEach(([idxStr, field]) => {
+        entry[field] = String(row[Number(idxStr)] ?? '').trim();
+      });
+      return entry;
+    })
+    .filter((entry) => entry.chineseTerm);
+}
+
+// Dispatches on file extension. Throws GlossaryParseError for anything worth showing the user.
+export async function parseGlossaryFile(file: File): Promise<GlossaryImportRow[]> {
+  const lowerName = file.name.toLowerCase();
+
+  let rows: GlossaryImportRow[];
+  if (lowerName.endsWith('.csv')) {
+    rows = parseGlossaryCSV(await file.text());
+  } else if (lowerName.endsWith('.xlsx') || lowerName.endsWith('.xls')) {
+    rows = await parseGlossaryXLSX(file);
+  } else {
+    throw new GlossaryParseError('Invalid file type. Please upload a CSV or XLSX file.');
+  }
+
+  if (rows.length === 0) {
+    throw new GlossaryParseError('No valid rows found. Ensure the file has a ChineseTerm column.');
+  }
+
+  return rows;
+}
+
+// Groups CSV/XLSX rows by UUID (if present) or Chinese term. One group = one glossary entry.
+// Mirrors the keying importGlossaries uses server-side, so the preview matches what gets written.
+export function groupRows(rows: GlossaryImportRow[]): GroupedTerm[] {
+  const byKey = new Map<string, GlossaryImportRow[]>();
+  for (const row of rows) {
+    const key = row.uuid || `term:${row.chineseTerm}`;
+    const bucket = byKey.get(key) ?? [];
+    bucket.push(row);
+    byKey.set(key, bucket);
+  }
+  return [...byKey.entries()].map(([key, groupRows]) => ({ key, rows: groupRows }));
+}
+
+// Splits groups into CHUNK_SIZE-term batches, flattened back to rows for posting.
+export function chunkGroupsToRows(groups: GroupedTerm[]): GlossaryImportRow[][] {
+  const queue: GlossaryImportRow[][] = [];
+  for (let i = 0; i < groups.length; i += CHUNK_SIZE) {
+    queue.push(groups.slice(i, i + CHUNK_SIZE).flatMap((g) => g.rows));
+  }
+  return queue;
+}

--- a/app/services/glossary.parse.ts
+++ b/app/services/glossary.parse.ts
@@ -24,7 +24,12 @@ export type GlossaryImportRow = {
 };
 
 export type GroupedTerm = {
+  // The Chinese term. This is the group's identity — see groupRows.
   key: string;
+  // First non-empty UUID among the rows; '' when the file supplied none.
+  uuid: string;
+  // Set when the rows for this term disagree on UUID, which makes the file ambiguous.
+  uuidConflict: boolean;
   rows: GlossaryImportRow[];
 };
 
@@ -139,17 +144,33 @@ export async function parseGlossaryFile(file: File): Promise<GlossaryImportRow[]
   return rows;
 }
 
-// Groups CSV/XLSX rows by UUID (if present) or Chinese term. One group = one glossary entry.
-// Mirrors the keying importGlossaries uses server-side, so the preview matches what gets written.
+// Groups rows into one entry per Chinese term. One group = one glossary entry.
+//
+// The term — not the UUID — is the identity, because `unique_glossary_idx` permits only one
+// row per term. Keying on UUID instead would let a UUID-bearing row and a bare row for the
+// same term become two groups that the database can never hold at once. A UUID is still
+// carried along so a newly created entry can keep the id from the file.
+//
+// Sorted by term so chunk boundaries are deterministic and the preview reads alphabetically.
 export function groupRows(rows: GlossaryImportRow[]): GroupedTerm[] {
-  const byKey = new Map<string, GlossaryImportRow[]>();
+  const byTerm = new Map<string, GlossaryImportRow[]>();
   for (const row of rows) {
-    const key = row.uuid || `term:${row.chineseTerm}`;
-    const bucket = byKey.get(key) ?? [];
+    const bucket = byTerm.get(row.chineseTerm) ?? [];
     bucket.push(row);
-    byKey.set(key, bucket);
+    byTerm.set(row.chineseTerm, bucket);
   }
-  return [...byKey.entries()].map(([key, groupRows]) => ({ key, rows: groupRows }));
+
+  return [...byTerm.entries()]
+    .map(([term, termRows]) => {
+      const uuids = [...new Set(termRows.map((r) => r.uuid).filter(Boolean))];
+      return {
+        key: term,
+        uuid: uuids[0] ?? '',
+        uuidConflict: uuids.length > 1,
+        rows: termRows,
+      };
+    })
+    .sort((a, b) => a.key.localeCompare(b.key, 'zh-Hans-CN'));
 }
 
 // Splits groups into CHUNK_SIZE-term batches, flattened back to rows for posting.

--- a/app/services/glossary.service.ts
+++ b/app/services/glossary.service.ts
@@ -6,7 +6,7 @@ import { glossariesTable, type CreateGlossary, type ReadGlossary, type UpdateGlo
 import { getDb } from '~/lib/db.server';
 import algoliaClient from '~/providers/algolia';
 
-import { type GlossaryImportRow } from './glossary.parse';
+import { groupRows, type GlossaryImportRow } from './glossary.parse';
 
 // Re-exported so callers of importGlossaries can reach the row type from one place.
 // The parsers themselves live in glossary.parse.ts because they run in the browser.
@@ -285,26 +285,18 @@ export type ImportGlossaryResult = {
 };
 
 export const importGlossaries = async (rows: GlossaryImportRow[], userId: string): Promise<ImportGlossaryResult> => {
-  // Group rows by UUID (falling back to chineseTerm as the dedup key)
-  const byKey = new Map<string, GlossaryImportRow[]>();
-  for (const row of rows) {
-    const key = row.uuid || `term:${row.chineseTerm}`;
-    const bucket = byKey.get(key) ?? [];
-    bucket.push(row);
-    byKey.set(key, bucket);
-  }
+  // Same grouping the preview uses, so what gets written matches what was reviewed.
+  const groups = groupRows(rows);
 
-  const uuidKeys = [...byKey.keys()].filter((k) => !k.startsWith('term:'));
-  // Collect every Chinese term across all groups (UUID-keyed and term-keyed alike) for a single term lookup.
-  const allTerms = [...byKey.values()].map((rows) => rows[0].chineseTerm);
+  const uuids = groups.map((g) => g.uuid).filter(Boolean);
+  const terms = groups.map((g) => g.key);
 
   const [existingByUuid, existingByTerm] = await Promise.all([
-    uuidKeys.length > 0 ? readGlossariesByIds(uuidKeys) : Promise.resolve([]),
-    allTerms.length > 0 ? getGlossariesByGivenGlossaries(allTerms) : Promise.resolve([]),
+    uuids.length > 0 ? readGlossariesByIds(uuids) : Promise.resolve([]),
+    terms.length > 0 ? getGlossariesByGivenGlossaries(terms) : Promise.resolve([]),
   ]);
 
   const idMap = new Map(existingByUuid.map((g) => [g.id, g]));
-  // termMap covers all groups, so UUID-keyed rows can fall back to it when the UUID is unknown.
   const termMap = new Map(existingByTerm.map((g) => [g.glossary, g]));
 
   let created = 0;
@@ -312,15 +304,13 @@ export const importGlossaries = async (rows: GlossaryImportRow[], userId: string
   let failed = 0;
   const now = new Date().toISOString();
 
-  const entries = [...byKey.entries()];
-
-  for (let i = 0; i < entries.length; i += IMPORT_CONCURRENCY) {
-    const batch = entries.slice(i, i + IMPORT_CONCURRENCY);
+  for (let i = 0; i < groups.length; i += IMPORT_CONCURRENCY) {
+    const batch = groups.slice(i, i + IMPORT_CONCURRENCY);
 
     const results = await Promise.allSettled(
-      batch.map(async ([key, csvRows]) => {
-        const first = csvRows[0];
-        const translations = csvRows
+      batch.map(async (group) => {
+        const first = group.rows[0];
+        const translations = group.rows
           .filter((r) => r.englishTerm)
           .map((r) => ({
             glossary: r.englishTerm,
@@ -334,9 +324,9 @@ export const importGlossaries = async (rows: GlossaryImportRow[], userId: string
             author: r.author || null,
           }));
 
-        const isUUID = !key.startsWith('term:');
-        // For UUID-keyed rows: match by ID first, fall back to term in case the record exists under a different/no ID.
-        const existing = isUUID ? (idMap.get(key) ?? termMap.get(first.chineseTerm)) : termMap.get(first.chineseTerm);
+        // Match on the supplied id first, then fall back to the term, which is what the
+        // unique index actually constrains.
+        const existing = (group.uuid ? idMap.get(group.uuid) : undefined) ?? termMap.get(group.key);
 
         if (existing) {
           await updateGlossaryTranslations({
@@ -351,8 +341,8 @@ export const importGlossaries = async (rows: GlossaryImportRow[], userId: string
           return 'updated' as const;
         } else {
           await createGlossaryAndIndexInAlgolia({
-            ...(isUUID ? { id: key } : {}),
-            glossary: first.chineseTerm,
+            ...(group.uuid ? { id: group.uuid } : {}),
+            glossary: group.key,
             phonetic: first.phonetic || null,
             cbetaFrequency: first.cbetaFrequency || null,
             author: first.author || null,

--- a/app/services/glossary.service.ts
+++ b/app/services/glossary.service.ts
@@ -1,10 +1,16 @@
-import { eq, inArray, sql } from 'drizzle-orm';
+import { eq, inArray, isNotNull, sql } from 'drizzle-orm';
 import OpenAI from 'openai';
 import 'dotenv/config';
 
 import { glossariesTable, type CreateGlossary, type ReadGlossary, type UpdateGlossary } from '~/drizzle/tables';
 import { getDb } from '~/lib/db.server';
 import algoliaClient from '~/providers/algolia';
+
+import { type GlossaryImportRow } from './glossary.parse';
+
+// Re-exported so callers of importGlossaries can reach the row type from one place.
+// The parsers themselves live in glossary.parse.ts because they run in the browser.
+export type { GlossaryImportRow } from './glossary.parse';
 
 const dbClient = getDb();
 
@@ -272,19 +278,6 @@ export const getAllGlossaries = async (): Promise<ReadGlossary[]> => {
   return glossaries;
 };
 
-export type GlossaryImportRow = {
-  uuid: string;
-  chineseTerm: string;
-  englishTerm: string;
-  chineseSutraText: string;
-  englishSutraText: string;
-  sutraName: string;
-  volume: string;
-  cbetaFrequency: string;
-  author: string;
-  phonetic: string;
-};
-
 export type ImportGlossaryResult = {
   created: number;
   updated: number;
@@ -397,4 +390,24 @@ export const deleteGlossariesByUserId = async (userId: string) => {
     objectIDs: glossaryIds,
   });
   return await dbClient.delete(glossariesTable).where(eq(glossariesTable.createdBy, userId));
+};
+
+// Empties the glossary table and drops its objects from the Algolia index.
+// Destructive and irreversible — callers must gate this on the appropriate ability.
+export const deleteAllGlossaries = async (): Promise<{ deleted: number }> => {
+  // Only rows that were actually indexed carry a searchId.
+  const rows = await dbClient
+    .select({ searchId: glossariesTable.searchId })
+    .from(glossariesTable)
+    .where(isNotNull(glossariesTable.searchId));
+
+  const objectIDs = rows.map((r) => r.searchId).filter((id): id is string => Boolean(id));
+
+  // Remove only the objects this table owns rather than clearing the shared index. deleteObjects auto-batches.
+  if (objectIDs.length > 0) {
+    await algoliaClient.deleteObjects({ indexName: 'glossaries', objectIDs });
+  }
+
+  const deleted = await dbClient.delete(glossariesTable).returning({ id: glossariesTable.id });
+  return { deleted: deleted.length };
 };

--- a/tests/ability.test.ts
+++ b/tests/ability.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import { defineAbilityFor } from '~/authorisation/ability';
+import { ROLE_VALUES, type UserRole } from '~/utils/constants';
+
+const abilityFor = (role: UserRole) => defineAbilityFor({ role });
+
+// ─── Glossary ────────────────────────────────────────────────────────────────
+
+describe('defineAbilityFor — Glossary', () => {
+  // Replacing the glossary deletes every entry, so this is the gate the replace route leans on.
+  it('grants Delete to admin only', () => {
+    expect(abilityFor('admin').can('Delete', 'Glossary')).toBe(true);
+
+    for (const role of ROLE_VALUES.filter((r) => r !== 'admin')) {
+      expect(abilityFor(role).can('Delete', 'Glossary'), `${role} must not delete the glossary`).toBe(false);
+    }
+  });
+
+  it('grants Update to admin, editor, leader and manager', () => {
+    const allowed: UserRole[] = ['admin', 'editor', 'leader', 'manager'];
+
+    for (const role of ROLE_VALUES) {
+      expect(abilityFor(role).can('Update', 'Glossary'), role).toBe(allowed.includes(role));
+    }
+  });
+
+  // Create is what gates bulk import, so manager holds it alongside Read DataManagement.
+  it('grants Create to admin and manager', () => {
+    const allowed: UserRole[] = ['admin', 'manager'];
+
+    for (const role of ROLE_VALUES) {
+      expect(abilityFor(role).can('Create', 'Glossary'), role).toBe(allowed.includes(role));
+    }
+  });
+
+  // Exporting the whole glossary — both download routes enforce this, not just the icon.
+  it('grants Download to admin and manager', () => {
+    const allowed: UserRole[] = ['admin', 'manager'];
+
+    for (const role of ROLE_VALUES) {
+      expect(abilityFor(role).can('Download', 'Glossary'), role).toBe(allowed.includes(role));
+    }
+  });
+});
+
+// ─── Menu-driving abilities ──────────────────────────────────────────────────
+
+describe('defineAbilityFor — abilities the sidebar reads', () => {
+  it('grants Read DataManagement to admin and manager', () => {
+    const allowed: UserRole[] = ['admin', 'manager'];
+
+    for (const role of ROLE_VALUES) {
+      expect(abilityFor(role).can('Read', 'DataManagement'), role).toBe(allowed.includes(role));
+    }
+  });
+
+  it('grants Read Administration to admin only', () => {
+    for (const role of ROLE_VALUES) {
+      expect(abilityFor(role).can('Read', 'Administration'), role).toBe(role === 'admin');
+    }
+  });
+
+  // A role that can open the Data Management menu but can't write the glossary would find the
+  // section visible and useless — which is exactly why manager holds Create Glossary.
+  it('gives every role that can reach Data Management a usable glossary tool', () => {
+    for (const role of ROLE_VALUES) {
+      const ability = abilityFor(role);
+      if (ability.can('Read', 'DataManagement')) {
+        expect(ability.can('Create', 'Glossary'), `${role} can open Data Management but cannot import`).toBe(true);
+      }
+    }
+  });
+});
+
+// ─── Regression: reader is the least-privileged role ─────────────────────────
+
+describe('defineAbilityFor — reader', () => {
+  it('grants a reader no glossary or data-management access at all', () => {
+    const reader = abilityFor('reader');
+
+    expect(reader.can('Create', 'Glossary')).toBe(false);
+    expect(reader.can('Update', 'Glossary')).toBe(false);
+    expect(reader.can('Delete', 'Glossary')).toBe(false);
+    expect(reader.can('Download', 'Glossary')).toBe(false);
+    expect(reader.can('Read', 'DataManagement')).toBe(false);
+    expect(reader.can('Read', 'Administration')).toBe(false);
+  });
+});

--- a/tests/glossary.export.test.ts
+++ b/tests/glossary.export.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import { read, utils } from 'xlsx';
+
+import { type ReadGlossary } from '~/drizzle/tables';
+import {
+  GLOSSARY_EXPORT_HEADERS,
+  glossariesToCSV,
+  glossariesToExportRows,
+  glossariesToXLSX,
+  parseExportFormat,
+} from '~/services/glossary.export';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+type Translation = NonNullable<ReadGlossary['translations']>[number];
+
+function makeTranslation(overrides: Partial<Translation> & { glossary: string }): Translation {
+  return {
+    language: 'english',
+    sutraName: '',
+    volume: '',
+    updatedBy: '',
+    updatedAt: '',
+    ...overrides,
+  } as Translation;
+}
+
+function makeGlossary(overrides: Partial<ReadGlossary> & { glossary: string }): ReadGlossary {
+  return {
+    id: 'id-1',
+    phonetic: null,
+    cbetaFrequency: null,
+    translations: [],
+    ...overrides,
+  } as ReadGlossary;
+}
+
+// ─── glossariesToExportRows ──────────────────────────────────────────────────
+
+describe('glossariesToExportRows', () => {
+  it('emits one row per translation, carrying entry-level fields onto each', () => {
+    const rows = glossariesToExportRows([
+      makeGlossary({
+        id: 'abc',
+        glossary: '菩薩',
+        phonetic: 'púsà',
+        cbetaFrequency: '500',
+        translations: [
+          makeTranslation({ glossary: 'bodhisattva', sutraName: 'Lotus', volume: '1' }),
+          makeTranslation({ glossary: 'enlightened being' }),
+        ],
+      }),
+    ]);
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({ UUID: 'abc', ChineseTerm: '菩薩', EnglishTerm: 'bodhisattva', Phonetic: 'púsà' });
+    expect(rows[1]).toMatchObject({ ChineseTerm: '菩薩', EnglishTerm: 'enlightened being', CBetaFrequency: '500' });
+  });
+
+  it('drops entries that have no translations', () => {
+    const rows = glossariesToExportRows([makeGlossary({ glossary: '空', translations: [] })]);
+    expect(rows).toEqual([]);
+  });
+
+  it('renders null entry/translation fields as empty strings', () => {
+    const rows = glossariesToExportRows([
+      makeGlossary({
+        glossary: '法',
+        phonetic: null,
+        cbetaFrequency: null,
+        translations: [makeTranslation({ glossary: 'dharma', originSutraText: null, author: null })],
+      }),
+    ]);
+
+    expect(rows[0].Phonetic).toBe('');
+    expect(rows[0].CBetaFrequency).toBe('');
+    expect(rows[0].ChineseSutraText).toBe('');
+    expect(rows[0].Author).toBe('');
+  });
+});
+
+// ─── glossariesToCSV ─────────────────────────────────────────────────────────
+
+describe('glossariesToCSV', () => {
+  it('starts with the fixed header row', () => {
+    const csv = glossariesToCSV([]);
+    expect(csv).toBe(GLOSSARY_EXPORT_HEADERS.join(','));
+  });
+
+  it('quotes and escapes values containing commas, quotes or newlines', () => {
+    const csv = glossariesToCSV([
+      makeGlossary({
+        glossary: '慈悲',
+        translations: [
+          makeTranslation({
+            glossary: 'compassion, kindness',
+            originSutraText: 'has "quotes"',
+            targetSutraText: 'line1\nline2',
+          }),
+        ],
+      }),
+    ]);
+
+    const dataLine = csv.split('\n').slice(1).join('\n');
+    expect(dataLine).toContain('"compassion, kindness"');
+    expect(dataLine).toContain('"has ""quotes"""');
+    expect(dataLine).toContain('"line1\nline2"');
+  });
+});
+
+// ─── glossariesToXLSX ────────────────────────────────────────────────────────
+
+describe('glossariesToXLSX', () => {
+  it('round-trips headers and values through a real workbook', async () => {
+    const bytes = await glossariesToXLSX([
+      makeGlossary({
+        id: 'abc',
+        glossary: '菩薩',
+        translations: [makeTranslation({ glossary: 'bodhisattva', sutraName: 'Lotus', volume: '1' })],
+      }),
+    ]);
+
+    const workbook = read(bytes, { type: 'array' });
+    const sheet = workbook.Sheets[workbook.SheetNames[0]];
+    const parsed = utils.sheet_to_json<Record<string, string>>(sheet, { defval: '', raw: false });
+
+    expect(parsed).toHaveLength(1);
+    expect(Object.keys(parsed[0])).toEqual([...GLOSSARY_EXPORT_HEADERS]);
+    expect(parsed[0]).toMatchObject({
+      UUID: 'abc',
+      ChineseTerm: '菩薩',
+      EnglishTerm: 'bodhisattva',
+      SutraName: 'Lotus',
+    });
+  });
+
+  it('produces a header-only sheet for an empty glossary', async () => {
+    const bytes = await glossariesToXLSX([]);
+    const workbook = read(bytes, { type: 'array' });
+    const sheet = workbook.Sheets[workbook.SheetNames[0]];
+    const aoa = utils.sheet_to_json<string[]>(sheet, { header: 1 });
+
+    expect(aoa[0]).toEqual([...GLOSSARY_EXPORT_HEADERS]);
+    expect(aoa).toHaveLength(1);
+  });
+});
+
+// ─── parseExportFormat ───────────────────────────────────────────────────────
+
+describe('parseExportFormat', () => {
+  it('returns csv only for an explicit csv value', () => {
+    expect(parseExportFormat('csv')).toBe('csv');
+  });
+
+  it('defaults to xlsx for xlsx, missing or unrecognised values', () => {
+    expect(parseExportFormat('xlsx')).toBe('xlsx');
+    expect(parseExportFormat(null)).toBe('xlsx');
+    expect(parseExportFormat(undefined)).toBe('xlsx');
+    expect(parseExportFormat('exe')).toBe('xlsx');
+  });
+});

--- a/tests/glossary.parse.test.ts
+++ b/tests/glossary.parse.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+
+import { chunkGroupsToRows, CHUNK_SIZE, groupRows, type GlossaryImportRow } from '~/services/glossary.parse';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeRow(overrides: Partial<GlossaryImportRow> & { chineseTerm: string }): GlossaryImportRow {
+  return {
+    uuid: '',
+    englishTerm: '',
+    chineseSutraText: '',
+    englishSutraText: '',
+    sutraName: '',
+    volume: '',
+    cbetaFrequency: '',
+    author: '',
+    phonetic: '',
+    ...overrides,
+  };
+}
+
+// ─── groupRows ───────────────────────────────────────────────────────────────
+
+describe('groupRows', () => {
+  it('merges rows sharing a term into one group with a translation each', () => {
+    const groups = groupRows([
+      makeRow({ chineseTerm: '菩薩', englishTerm: 'bodhisattva' }),
+      makeRow({ chineseTerm: '菩薩', englishTerm: 'enlightened being' }),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe('菩薩');
+    expect(groups[0].rows).toHaveLength(2);
+  });
+
+  // The database permits one row per term (unique_glossary_idx), so a UUID-bearing row and a
+  // bare row for the same term must not become two groups — they could never both be written.
+  it('groups a UUID row and a bare row for the same term together', () => {
+    const groups = groupRows([
+      makeRow({ chineseTerm: '菩薩', englishTerm: 'bodhisattva', uuid: 'abc-123' }),
+      makeRow({ chineseTerm: '菩薩', englishTerm: 'enlightened being' }),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].uuid).toBe('abc-123');
+    expect(groups[0].uuidConflict).toBe(false);
+  });
+
+  it('carries the UUID even when it appears only on a later row', () => {
+    const groups = groupRows([
+      makeRow({ chineseTerm: '法', englishTerm: 'dharma' }),
+      makeRow({ chineseTerm: '法', englishTerm: 'law', uuid: 'def-456' }),
+    ]);
+
+    expect(groups[0].uuid).toBe('def-456');
+    expect(groups[0].uuidConflict).toBe(false);
+  });
+
+  it('flags a conflict and keeps the first UUID when rows disagree', () => {
+    const groups = groupRows([
+      makeRow({ chineseTerm: '法', englishTerm: 'dharma', uuid: 'first-id' }),
+      makeRow({ chineseTerm: '法', englishTerm: 'law', uuid: 'second-id' }),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].uuid).toBe('first-id');
+    expect(groups[0].uuidConflict).toBe(true);
+  });
+
+  it('leaves uuid empty when the file supplies none', () => {
+    const groups = groupRows([makeRow({ chineseTerm: '空', englishTerm: 'emptiness' })]);
+
+    expect(groups[0].uuid).toBe('');
+    expect(groups[0].uuidConflict).toBe(false);
+  });
+
+  it('keeps distinct terms in separate groups', () => {
+    const groups = groupRows([
+      makeRow({ chineseTerm: '菩薩', englishTerm: 'bodhisattva' }),
+      makeRow({ chineseTerm: '法', englishTerm: 'dharma' }),
+    ]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups.map((g) => g.key).sort()).toEqual(['法', '菩薩'].sort());
+  });
+
+  it('orders groups deterministically regardless of row order', () => {
+    const rows = [makeRow({ chineseTerm: '空' }), makeRow({ chineseTerm: '菩薩' }), makeRow({ chineseTerm: '法' })];
+
+    const forward = groupRows(rows).map((g) => g.key);
+    const reversed = groupRows([...rows].reverse()).map((g) => g.key);
+
+    expect(forward).toEqual(reversed);
+  });
+
+  it('returns no groups for no rows', () => {
+    expect(groupRows([])).toEqual([]);
+  });
+});
+
+// ─── chunkGroupsToRows ───────────────────────────────────────────────────────
+
+describe('chunkGroupsToRows', () => {
+  it('keeps every row of a term inside a single chunk', () => {
+    // One term with more rows than a chunk holds: it must still not be split.
+    const rows = Array.from({ length: CHUNK_SIZE + 5 }, (_, i) =>
+      makeRow({ chineseTerm: '菩薩', englishTerm: `translation ${i}` }),
+    );
+
+    const chunks = chunkGroupsToRows(groupRows(rows));
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toHaveLength(CHUNK_SIZE + 5);
+  });
+
+  it('splits on group boundaries, not row boundaries', () => {
+    const rows = Array.from({ length: CHUNK_SIZE + 1 }, (_, i) => makeRow({ chineseTerm: `term-${i}` }));
+
+    const chunks = chunkGroupsToRows(groupRows(rows));
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toHaveLength(CHUNK_SIZE);
+    expect(chunks[1]).toHaveLength(1);
+  });
+
+  it('preserves every row across chunks', () => {
+    const rows = Array.from({ length: 40 }, (_, i) => makeRow({ chineseTerm: `term-${i}`, englishTerm: `en-${i}` }));
+
+    const chunks = chunkGroupsToRows(groupRows(rows));
+
+    expect(chunks.flat()).toHaveLength(40);
+    expect(new Set(chunks.flat().map((r) => r.chineseTerm)).size).toBe(40);
+  });
+
+  it('returns no chunks for no groups', () => {
+    expect(chunkGroupsToRows([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
This adds a new data management route for only admins, to completely replace the glossary with imported data.
This also changes the default export file to xlsx.