### PR TITLE
import references via spreadsheet

### DIFF
--- a/app/components/data/DocumentRow.tsx
+++ b/app/components/data/DocumentRow.tsx
@@ -52,7 +52,7 @@ export function DocumentRow({ document, canDelete, isEditing, onEditToggle, onEd
           {document.subtitle && <div className="text-muted-foreground text-xs">{document.subtitle}</div>}
           <div className="text-muted-foreground mt-0.5 flex items-center gap-2 text-xs">
             <span className="bg-muted rounded-full px-2 py-0.5">
-              language=<span className="capitalize">{document.language}</span>
+              <span className="capitalize">{document.language}</span>
             </span>
             {document.key && (
               <span className="bg-muted rounded-full px-2 py-0.5">

--- a/app/components/data/DocumentRow.tsx
+++ b/app/components/data/DocumentRow.tsx
@@ -51,8 +51,14 @@ export function DocumentRow({ document, canDelete, isEditing, onEditToggle, onEd
           </div>
           {document.subtitle && <div className="text-muted-foreground text-xs">{document.subtitle}</div>}
           <div className="text-muted-foreground mt-0.5 flex items-center gap-2 text-xs">
-            <span className="bg-muted rounded-full px-2 py-0.5 capitalize">{document.language}</span>
-            {document.key && <span className="bg-muted rounded-full px-2 py-0.5 font-mono">{document.key}</span>}
+            <span className="bg-muted rounded-full px-2 py-0.5">
+              language=<span className="capitalize">{document.language}</span>
+            </span>
+            {document.key && (
+              <span className="bg-muted rounded-full px-2 py-0.5">
+                key=<span className="font-mono">{document.key}</span>
+              </span>
+            )}
             {document.contributors.length > 0 && (
               <span>{document.contributors.map((c) => `${c.name} (${c.role})`).join(', ')}</span>
             )}

--- a/app/components/data/ProjectRow.tsx
+++ b/app/components/data/ProjectRow.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import { DeleteEntityButton } from './DeleteEntityButton';
 import { ProjectForm, type ProjectForForm } from './ProjectForm';
-import { SectionForm } from './SectionForm';
+import { SectionForm, type ReferenceSectionForForm } from './SectionForm';
 import { SectionRow } from './SectionRow';
 
 type Section = {
@@ -23,12 +23,19 @@ type Document = {
   sections: Section[];
 };
 
+// A reference document attached to the project, with its own sections so the
+// section editor can show/name a counterpart at each order.
+type ProjectReference = {
+  documentId: string;
+  document: { id: string; key: string | null; title: string; sections: Section[] };
+};
+
 export type ProjectForRow = {
   id: string;
   name: string;
   sourceDocument: Document;
   targetDocument: Document;
-  references: { documentId: string }[];
+  references: ProjectReference[];
 };
 
 // Works (with their documents) scope the source/target/reference pickers in the
@@ -64,6 +71,8 @@ type DraggableItemProps = {
   // The counterpart section in the target document (matched by order), when it
   // exists — its id/title feed the edit form so updates hit the real section.
   targetSection: { id: string; title: string | null } | null;
+  // Each reference document's counterpart section for this row (matched by order).
+  references: ReferenceSectionForForm[];
   hasData: boolean;
   isEditing: boolean;
   onEditToggle: () => void;
@@ -76,6 +85,7 @@ function DraggableSectionRow({
   documentId,
   targetDocumentId,
   targetSection,
+  references,
   hasData,
   isEditing,
   onEditToggle,
@@ -98,6 +108,7 @@ function DraggableSectionRow({
         hasData={hasData}
         isEditing={isEditing}
         documentId={documentId}
+        references={references}
         onEditClose={onEditClose}
         onEditToggle={onEditToggle}
         dragControls={dragControls}
@@ -144,8 +155,24 @@ export function ProjectRow({
     workId: project.sourceDocument.workId,
     sourceDocumentId: project.sourceDocument.id,
     targetDocumentId: project.targetDocument.id,
-    references: project.references,
+    references: project.references.map((r) => ({ documentId: r.documentId })),
   };
+
+  const referenceLabel = (doc: ProjectReference['document']) => doc.key ?? doc.title;
+
+  // The reference title boxes for a given section order — its counterpart in each
+  // reference document when one exists (matched by order), else an empty box to
+  // create it. Order is undefined for the not-yet-created "Add Section" form.
+  const referencesForOrder = (order?: number): ReferenceSectionForForm[] =>
+    project.references.map((ref) => {
+      const counterpart = order === undefined ? null : (ref.document.sections.find((s) => s.order === order) ?? null);
+      return {
+        documentId: ref.documentId,
+        label: referenceLabel(ref.document),
+        sectionId: counterpart?.id ?? null,
+        title: counterpart?.title ?? '',
+      };
+    });
 
   return (
     <div className="border-border bg-background overflow-hidden rounded-lg border shadow-sm">
@@ -239,6 +266,7 @@ export function ProjectRow({
                     hasData={sectionsWithData.has(section.id)}
                     isEditing={editingSectionId === section.id}
                     targetDocumentId={project.targetDocument.id}
+                    references={referencesForOrder(section.order)}
                     onEditToggle={() => onEditSectionToggle(section.id)}
                     targetSection={targetByOrder.get(section.order) ?? null}
                   />
@@ -253,6 +281,7 @@ export function ProjectRow({
             <div className="border-border border-t p-4">
               <SectionForm
                 onClose={onAddSectionClose}
+                references={referencesForOrder()}
                 documentId={project.sourceDocument.id}
                 targetDocumentId={project.targetDocument.id}
               />

--- a/app/components/data/SectionForm.tsx
+++ b/app/components/data/SectionForm.tsx
@@ -13,15 +13,26 @@ export type SectionForForm = {
   translationTitle: string;
 };
 
+// A reference document as it appears in the section editor: its counterpart
+// section (matched by order) when it exists, and the title to seed the box.
+export type ReferenceSectionForForm = {
+  documentId: string;
+  label: string;
+  sectionId: string | null;
+  title: string;
+};
+
 export function SectionForm({
   section,
   documentId,
   targetDocumentId,
+  references = [],
   onClose,
 }: {
   section?: SectionForForm;
   documentId: string;
   targetDocumentId?: string | null;
+  references?: ReferenceSectionForForm[];
   onClose: () => void;
 }) {
   const fetcher = useFetcher<{ success: boolean }>();
@@ -85,6 +96,33 @@ export function SectionForm({
             </div>
           </div>
         </div>
+
+        {references.length > 0 && (
+          <div className="border-primary-foreground/20 space-y-3 border-t pt-4">
+            <p className="text-primary-foreground/70 text-xs font-semibold tracking-wider uppercase">References</p>
+            <p className="text-primary-foreground/60 text-xs">
+              Give a reference a title to create (or rename) its section at this same order — this is what lets you
+              import data into that reference. Leave blank to skip.
+            </p>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              {references.map((ref) => (
+                <div key={ref.documentId}>
+                  {/* Aligned parallel inputs — read back with formData.getAll. */}
+                  <input type="hidden" value={ref.documentId} name="referenceSectionDocumentId" />
+                  <input type="hidden" name="referenceSectionId" value={ref.sectionId ?? ''} />
+                  <label className="text-primary-foreground/70 mb-1 block text-xs font-medium">{ref.label}</label>
+                  <textarea
+                    rows={2}
+                    defaultValue={ref.title}
+                    name="referenceSectionTitle"
+                    className={textareaClass(bg)}
+                    placeholder="e.g., Volume One"
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
 
         <div className="flex justify-end gap-3 pt-1">
           <button

--- a/app/components/data/SectionRow.tsx
+++ b/app/components/data/SectionRow.tsx
@@ -2,7 +2,7 @@ import type { DragControls } from 'framer-motion';
 
 import { Download, FileText, GripVertical, Pencil, Upload } from 'lucide-react';
 
-import { SectionForm } from './SectionForm';
+import { SectionForm, type ReferenceSectionForForm } from './SectionForm';
 
 type Section = {
   id: string;
@@ -18,6 +18,9 @@ type Props = {
   // exists. Feeds both the "/ translation title" display and the edit form —
   // so edits update the real counterpart instead of creating a duplicate.
   targetSection?: { id: string; title: string | null } | null;
+  // Each reference document's counterpart section (matched by order) for this
+  // row — feeds the reference title boxes in the editor and the display line.
+  references?: ReferenceSectionForForm[];
   // Whether the section has paragraph data (paragraphs_new); without data
   // there is nothing to export.
   hasData: boolean;
@@ -32,6 +35,7 @@ export function SectionRow({
   documentId,
   targetDocumentId,
   targetSection,
+  references = [],
   hasData,
   isEditing,
   onEditToggle,
@@ -39,6 +43,7 @@ export function SectionRow({
   dragControls,
 }: Props) {
   const targetTitle = targetSection?.title ?? null;
+  const namedReferences = references.filter((r) => r.sectionId && r.title);
 
   return (
     <div>
@@ -65,6 +70,11 @@ export function SectionRow({
                 <Pencil size={12} />
               </button>
             </p>
+            {namedReferences.length > 0 && (
+              <p className="text-muted-foreground mt-0.5 text-xs">
+                {namedReferences.map((r) => `${r.label}: ${r.title}`).join(' · ')}
+              </p>
+            )}
           </div>
         </div>
         <div className="flex flex-row justify-end gap-5">
@@ -100,6 +110,7 @@ export function SectionRow({
           <SectionForm
             onClose={onEditClose}
             documentId={documentId}
+            references={references}
             targetDocumentId={targetDocumentId}
             section={{
               sectionId: section.id,

--- a/app/components/import/DataComparisonPanel.tsx
+++ b/app/components/import/DataComparisonPanel.tsx
@@ -103,14 +103,14 @@ export function DataComparisonPanel({ existing, fileRows, formValues, isSubmitti
           </div>
         </div>
 
-        {/* Replace action — only shown after a file has been previewed */}
+        {/* Import action — only shown after a file has been previewed */}
         {fileRows && formValues && (
           <>
             <Alert>
               <AlertCircle className="h-4 w-4" />
               <AlertDescription>
-                <strong>Warning:</strong> Clicking "Replace Data" will permanently delete all existing paragraphs and
-                references for this section and replace them with the file data. This action cannot be undone.
+                Clicking "Import Data" adds or updates the rows in the file, matched by passage key and/or position.
+                Existing paragraphs not present in the file are left unchanged — nothing is deleted.
               </AlertDescription>
             </Alert>
 
@@ -122,8 +122,8 @@ export function DataComparisonPanel({ existing, fileRows, formValues, isSubmitti
               <input type="hidden" name="targetDocumentId" value={formValues.targetDocumentId} />
 
               <div className="flex justify-end gap-3">
-                <Button type="submit" variant="destructive" className="text-base" disabled={isSubmitting}>
-                  {isSubmitting && navigationIntent === 'replace' ? 'Replacing...' : 'Replace Data'}
+                <Button type="submit" className="text-base" disabled={isSubmitting}>
+                  {isSubmitting && navigationIntent === 'replace' ? 'Importing...' : 'Import Data'}
                 </Button>
               </div>
             </Form>

--- a/app/components/import/ImportInstructions.tsx
+++ b/app/components/import/ImportInstructions.tsx
@@ -1,35 +1,112 @@
 import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
 
-export function ImportInstructions() {
+type Props = {
+  originKey: string | null;
+  targetKey: string | null;
+  referenceKeys: string[];
+};
+
+export function ImportInstructions({ originKey, targetKey, referenceKeys }: Props) {
+  // Fall back to generic placeholders when a document has no key set yet.
+  const origin = originKey ?? 'origin';
+  const target = targetKey ?? 'translation';
+  const firstRef = referenceKeys[0];
+
+  // Example headers: the two main documents, the first reference (if any), then
+  // the reserved passage_key column.
+  const exampleColumns = [origin, target, ...(firstRef ? [firstRef] : []), 'passage_key'];
+  const csvExample = [
+    exampleColumns.join(','),
+    [`諸法因緣生`, `All dharmas arise from causes and conditions`, ...(firstRef ? ['…'] : []), 'T30n1579.1.1'].join(
+      ',',
+    ),
+    [`諸法因緣滅`, `All dharmas cease through causes and conditions`, ...(firstRef ? ['…'] : []), 'T30n1579.1.2'].join(
+      ',',
+    ),
+  ].join('\n');
+
   return (
     <Card className="mt-6">
       <CardHeader>
-        <CardTitle className="text-xl text-primary">File Format Instructions</CardTitle>
+        <CardTitle className="text-primary text-xl">File Format Instructions</CardTitle>
       </CardHeader>
-      <CardContent className="space-y-3 text-base">
+      <CardContent className="space-y-4 text-base">
         <div>
-          <h4 className="mb-1 text-base font-medium text-primary">CSV Format:</h4>
-          <pre className="overflow-x-auto rounded bg-muted p-3 text-sm text-muted-foreground">
-            {`origin,translation\n諸法因緣生,All dharmas arise from causes and conditions\n諸法因緣滅,All dharmas cease through causes and conditions`}
-          </pre>
-        </div>
-        <div>
-          <h4 className="mb-1 text-base font-medium text-primary">Excel Format:</h4>
-          <p className="text-base text-muted-foreground">
-            Create an Excel file with the same column structure. The first row should contain headers: "origin" and
-            "translation".
+          <h4 className="text-primary mb-1 text-base font-medium">Columns are document keys</h4>
+          <p className="text-muted-foreground text-base">
+            Each column header is the <strong>key</strong> of the document it fills. A document&apos;s key is shown next
+            to it in Data Management → Works &amp; Documents. Headers are matched to keys case-insensitively.
           </p>
         </div>
+
         <div>
-          <h4 className="mb-1 text-base font-medium text-primary">Notes:</h4>
-          <ul className="list-inside list-disc space-y-1 text-base text-muted-foreground">
-            <li>The "origin" column is required (also accepts "original" for backwards compatibility)</li>
-            <li>The "translation" column is optional (also accepts "target")</li>
-            <li>All other columns will be ignored</li>
-            <li>Column names are case-insensitive</li>
-            <li>Empty rows will be skipped</li>
+          <h4 className="text-primary mb-1 text-base font-medium">This section&apos;s keys</h4>
+          <ul className="text-muted-foreground list-inside list-disc space-y-1 text-base">
             <li>
-              Importing will <strong>replace</strong> all existing data for the selected roll
+              Origin: <code className="bg-muted rounded px-1 font-mono">{origin}</code>
+              {!originKey && ' — no key set yet; set one in Works & Documents'}
+            </li>
+            <li>
+              Translation: <code className="bg-muted rounded px-1 font-mono">{target}</code>
+              {!targetKey && ' — no key set yet; set one in Works & Documents'}
+            </li>
+            {referenceKeys.length > 0 && (
+              <li>
+                References:{' '}
+                {referenceKeys.map((k, i) => (
+                  <span key={k}>
+                    {i > 0 && ', '}
+                    <code className="bg-muted rounded px-1 font-mono">{k}</code>
+                  </span>
+                ))}
+              </li>
+            )}
+            <li>
+              <code className="bg-muted rounded px-1 font-mono">passage_key</code> — optional; the shared identity for a
+              row across every document
+            </li>
+          </ul>
+        </div>
+
+        <div>
+          <h4 className="text-primary mb-1 text-base font-medium">CSV example</h4>
+          <pre className="bg-muted text-muted-foreground overflow-x-auto rounded p-3 text-sm">{csvExample}</pre>
+          <p className="text-muted-foreground mt-1 text-base">
+            An XLSX file works the same way — put the document keys in the first (header) row.
+          </p>
+        </div>
+
+        <div>
+          <h4 className="text-primary mb-1 text-base font-medium">How rows are matched</h4>
+          <ul className="text-muted-foreground list-inside list-disc space-y-1 text-base">
+            <li>
+              Include <strong>any subset</strong> of the documents — one column or all of them. A new reference can be
+              added later as a single column.
+            </li>
+            <li>
+              Rows are aligned to existing data by <strong>passage key and/or position</strong>, which must be
+              consistent with what&apos;s already stored. Add a <code className="font-mono">passage_key</code> column to
+              target specific passages regardless of row order.
+            </li>
+            <li>
+              The import is a pure upsert: matching rows are updated, new rows inserted, and{' '}
+              <strong>existing rows not in the file are left unchanged</strong> — nothing is deleted. So only the rows
+              that need changing need to be included.
+            </li>
+            <li>
+              Empty cells are skipped; a column that is entirely empty (or absent) leaves that document untouched.
+            </li>
+            <li>Fully-empty rows are ignored.</li>
+          </ul>
+        </div>
+
+        <div>
+          <h4 className="text-primary mb-1 text-base font-medium">Setup notes</h4>
+          <ul className="text-muted-foreground list-inside list-disc space-y-1 text-base">
+            <li>Each document&apos;s section (matched to this section by order) must already exist and be named.</li>
+            <li>
+              Reference columns whose key isn&apos;t a reference on this project, or whose section isn&apos;t set up,
+              are skipped and reported after import.
             </li>
           </ul>
         </div>

--- a/app/routes/_app.data.translation._index.tsx
+++ b/app/routes/_app.data.translation._index.tsx
@@ -65,6 +65,17 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       );
     }
 
+    // Reference documents are aligned the same way — a section per reference at
+    // the SAME order, created only for references given a title.
+    const refDocumentIds = formData.getAll('referenceSectionDocumentId') as string[];
+    const refTitles = formData.getAll('referenceSectionTitle') as string[];
+    for (let i = 0; i < refDocumentIds.length; i++) {
+      const title = (refTitles[i] ?? '').trim();
+      if (refDocumentIds[i] && title) {
+        await createSection({ documentId: refDocumentIds[i], title, order: nextOrder }, user);
+      }
+    }
+
     return json({ success: true });
   }
 
@@ -78,20 +89,38 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
     await updateSection(sectionId, { title: originTitle }, user);
 
+    // The source section's order pairs every counterpart (translation and each
+    // reference), so fetch it once for any counterpart we may need to create.
+    const sourceSection = await getSection(sectionId);
+    if (!sourceSection) {
+      return json({ success: false, error: 'Section not found' }, { status: 404 });
+    }
+
     if (translationTitle) {
       if (childSectionId) {
         await updateSection(childSectionId, { title: translationTitle }, user);
       } else if (targetDocumentId) {
         // No counterpart yet — create it with the SAME order as the source
         // section, since order is how the two sides are paired everywhere.
-        const sourceSection = await getSection(sectionId);
-        if (!sourceSection) {
-          return json({ success: false, error: 'Section not found' }, { status: 404 });
-        }
         await createSection(
           { documentId: targetDocumentId, title: translationTitle, order: sourceSection.order },
           user,
         );
+      }
+    }
+
+    // References: upsert each reference document's counterpart section at this
+    // section's order — update it when it already exists, create it otherwise.
+    const refDocumentIds = formData.getAll('referenceSectionDocumentId') as string[];
+    const refSectionIds = formData.getAll('referenceSectionId') as string[];
+    const refTitles = formData.getAll('referenceSectionTitle') as string[];
+    for (let i = 0; i < refDocumentIds.length; i++) {
+      const title = (refTitles[i] ?? '').trim();
+      const refSectionId = refSectionIds[i] || null;
+      if (refSectionId) {
+        if (title) await updateSection(refSectionId, { title }, user);
+      } else if (refDocumentIds[i] && title) {
+        await createSection({ documentId: refDocumentIds[i], title, order: sourceSection.order }, user);
       }
     }
 

--- a/app/routes/_app.data.translation.import.tsx
+++ b/app/routes/_app.data.translation.import.tsx
@@ -15,6 +15,7 @@ import {
   type ImportOptionsNew,
   type ImportResult,
 } from '~/services/file.service';
+import { getProjectBySourceDocumentId, getProjectReferences } from '~/services/project.service';
 import { getDocument, getSection } from '~/services/text.service';
 
 import { assertAuthUser } from '../auth.server';
@@ -67,7 +68,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
     return redirect('/data');
   }
 
-  const existing = await getExistingDataPreviewForSection(originSectionId, targetDocumentId);
+  // Reference documents — the other columns an import file may carry, and the
+  // extra columns shown in the existing-data preview.
+  const project = await getProjectBySourceDocumentId(originDocumentId);
+  const references = project ? await getProjectReferences(project.id) : [];
+  const referenceDocuments = references.map((r) => ({ id: r.documentId, key: r.document?.key ?? null }));
+  const referenceKeys = referenceDocuments.map((r) => r.key).filter((k): k is string => !!k);
+
+  const existing = await getExistingDataPreviewForSection(originSectionId, targetDocumentId, referenceDocuments);
 
   return json({
     originDocumentId,
@@ -79,6 +87,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
     targetSectionName: targetSection?.title ?? '',
     originalLanguage: originDocument.language,
     translationLanguage: targetDocument.language,
+    originKey: originDocument.key,
+    targetKey: targetDocument.key,
+    referenceKeys,
     existing,
     userId: user.id,
   });
@@ -107,14 +118,23 @@ export async function action({ request }: ActionFunctionArgs) {
       );
     }
 
+    // Columns are identified by each document's key. Both keys are optional — the
+    // file may carry any subset of documents — so we pass whatever keys exist and
+    // let the parser match the columns that are present.
+    const [originDocument, targetDocument] = await Promise.all([
+      getDocument(originDocumentId),
+      getDocument(targetDocumentId),
+    ]);
+    const keys = { originKey: originDocument?.key ?? null, targetKey: targetDocument?.key ?? null };
+
     try {
       const fileName = file.name.toLowerCase();
       let rows: ExcelTranslationRow[];
 
       if (fileName.endsWith('.csv')) {
-        rows = await parseCSV(await file.text());
+        rows = await parseCSV(await file.text(), keys);
       } else if (fileName.endsWith('.xlsx') || fileName.endsWith('.xls')) {
-        rows = await parseXLSX(await file.arrayBuffer());
+        rows = await parseXLSX(await file.arrayBuffer(), keys);
       } else {
         return json<ActionResponse>(
           {
@@ -194,6 +214,9 @@ export default function DataImport() {
     targetSectionName,
     originalLanguage,
     translationLanguage,
+    originKey,
+    targetKey,
+    referenceKeys,
     existing,
   } = useLoaderData<typeof loader>();
   const actionData = useActionData<ActionResponse>();
@@ -214,8 +237,15 @@ export default function DataImport() {
         <CardHeader>
           <CardTitle className="text-primary text-2xl">Import Data</CardTitle>
           <CardDescription className="text-base">
-            Upload a CSV or XLSX file with columns: <strong>origin</strong>, <strong>translation</strong> (optional).
-            This will replace all existing data for the selected section.
+            Upload a CSV or XLSX file whose column headers are document keys
+            {originKey || targetKey ? (
+              <>
+                {' '}
+                (e.g. <strong>{originKey ?? 'origin'}</strong>, <strong>{targetKey ?? 'translation'}</strong>)
+              </>
+            ) : null}
+            . Include any subset of the documents — the rows are matched to existing data by passage key and/or
+            position, and existing rows not in the file are left unchanged.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
@@ -249,7 +279,7 @@ export default function DataImport() {
         navigationIntent={navigationIntent}
       />
 
-      <ImportInstructions />
+      <ImportInstructions originKey={originKey} targetKey={targetKey} referenceKeys={referenceKeys} />
     </div>
   );
 }

--- a/app/routes/_app.resources.export.$sectionId.tsx
+++ b/app/routes/_app.resources.export.$sectionId.tsx
@@ -33,6 +33,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const rows: ExcelTranslationRow[] = paragraphs.map((p) => ({
     origin: p.origin,
     target: p.target,
+    passageKey: p.passageKey ?? null,
     references: [],
   }));
 

--- a/app/services/file.server.ts
+++ b/app/services/file.server.ts
@@ -19,7 +19,7 @@ import 'dotenv/config';
 import { eq, inArray } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 
-import type { CreateParagraphNew } from '~/drizzle/schema';
+import type { CreateParagraphNew, ReadParagraphNew } from '~/drizzle/schema';
 
 import { paragraphsTable, paragraphsTableNew, referencesTable } from '~/drizzle/schema';
 import { getDb } from '~/lib/db.server';
@@ -33,7 +33,9 @@ import {
   type ImportResult,
 } from './file.service';
 import { readParagraphsByRollIdForLanguage } from './paragraph.service';
+import { DbProjectReferences, DbProjects } from './project.crud';
 import { saveParagraphsToAlgolia, updateParagraphsToAlgolia } from './search.server';
+import { DbParagraphsNew } from './text.crud';
 import { findTargetSection, getDocument, getSection, readParagraphsBySectionId } from './text.service';
 
 export const db = getDb();
@@ -352,25 +354,54 @@ export async function getExistingDataPreviewForRollId(
 // above stay for debugging until the migration completes.
 // ─────────────────────────────────────────────────────────────────────────────
 
+// Thrown when the file's passage keys / row order can't be reconciled with what
+// is already in the database. Carries a user-facing message returned verbatim
+// rather than wrapped as a generic failure.
+class ImportConflictError extends Error {}
+
+const normaliseKey = (key: string): string => key.trim().toLowerCase();
+
+// One document involved in an import: where its column data goes and how to read
+// that column from a row. `sectionId` is null when the document's counterpart
+// section doesn't exist yet. `write` is true when the file actually carries
+// content for this document (a document with no column, or an all-empty column,
+// is left untouched).
+type InvolvedDocument = {
+  label: string;
+  documentId: string;
+  sectionId: string | null;
+  getValue: (row: ExcelTranslationRow) => string | null;
+  write: boolean;
+};
+
 /**
- * Upsert imported rows into a section of the new data model, matching by order
- * position — same interaction as replaceRollData:
- *   - Existing origin paragraph at position N → UPDATE content (and its target)
- *   - No existing paragraph at position N → INSERT origin (and target)
- *   - Extra existing paragraphs beyond imported count → "park" by negating order
+ * Import a spreadsheet into the new data model, where every column is a document
+ * (origin, translation, and reference documents are all documents now). Columns
+ * are identified by each document's `key`; a `passage_key` column (optional)
+ * gives every document's paragraph on that row the same passage key.
  *
- * Origin/target pairing uses passage_key instead of parent_id: the target row
- * lives in the target document's counterpart section (matched by order) and
- * carries the same passage_key as its origin. Keys for new rows are generated
- * as `<work prefix>.<section order>.<row number>`.
+ * The file may carry ANY subset of the documents — one column or all of them —
+ * so a new reference can be added later as a single column and aligned to the
+ * data already present. Only documents whose column has content are written;
+ * documents absent from the file (or all-empty) are left untouched.
  *
- * The counterpart section is NEVER created implicitly — it must already exist
- * and be named (via Data Management) or the import is rejected. This keeps
- * section ids stable and avoids silently splitting a document's paragraphs
- * across duplicate sections.
+ * Rows are aligned across documents by passage key and/or position, which must
+ * be consistent with existing data. Each row's passage key is decided once, used
+ * by every document on that row:
+ *   - the `passage_key` cell, when present;
+ *   - otherwise the key already stored at that position (origin, translation or
+ *     a reference — they must agree);
+ *   - otherwise a generated `<work prefix>.<section order>.<row number>`.
+ * If the file's key/position disagrees with existing data (a position already
+ * keyed to something else, or documents keyed inconsistently at a position) the
+ * import is rejected with guidance so the admin can reconcile the database.
  *
- * References are NOT imported — they still belong to the legacy tables and are
- * reported as skipped until they move over in a later migration step.
+ * Per document, a paragraph is matched by passage key, else by an unkeyed row at
+ * the same position; matched rows are updated, unmatched inserted, and existing
+ * paragraphs of a WRITTEN document that the file didn't touch are parked. Each
+ * document's counterpart section (matched to the origin section by order) must
+ * already exist and be named — reference columns whose section is missing/unnamed
+ * (or whose key isn't a project reference) are skipped and reported.
  */
 export async function replaceSectionData(
   rows: ExcelTranslationRow[],
@@ -379,120 +410,231 @@ export async function replaceSectionData(
   const { originDocumentId, originSectionId, targetDocumentId, userId } = options;
 
   try {
-    const [originDocument, originSection] = await Promise.all([
+    const [originDocument, originSection, targetDocument] = await Promise.all([
       getDocument(originDocumentId),
       getSection(originSectionId),
+      getDocument(targetDocumentId),
     ]);
     if (!originDocument || !originSection) {
       return { success: false, message: 'Origin document or section not found.' };
     }
 
     const passageKeyPrefix = originDocument.work?.passageKeyPrefix ?? originDocument.workId;
+    const sectionOrder = originSection.order;
 
-    const targetSection = await findTargetSection({
-      sourceSection: { order: originSection.order },
-      targetDocumentId,
+    const has = (getValue: (row: ExcelTranslationRow) => string | null) => rows.some((r) => getValue(r)?.trim());
+
+    // ── Assemble the documents involved in this import ───────────────────────
+    const involved: InvolvedDocument[] = [];
+    const skippedColumns: string[] = [];
+
+    // Origin.
+    involved.push({
+      label: 'origin',
+      documentId: originDocumentId,
+      sectionId: originSectionId,
+      getValue: (row) => row.origin || null,
+      write: has((r) => r.origin || null),
     });
-    if (!targetSection) {
+
+    // Translation — its section must exist and be named when the file carries
+    // translation content; otherwise it's simply not written.
+    const targetSection = targetDocument
+      ? await findTargetSection({ sourceSection: { order: sectionOrder }, targetDocumentId })
+      : null;
+    const wantsTarget = has((r) => r.target);
+    if (wantsTarget && (!targetSection || !targetSection.title?.trim())) {
       return {
         success: false,
         message:
-          'The translation section for this section has not been created yet. ' +
-          'Create and name it in Data Management → Translation Projects (edit the section and set a translation title) before importing.',
+          'The translation section for this section has not been created and named yet. ' +
+          'Create and name it in Data Management → Translation Projects (edit the section and set a translation title) before importing translation data.',
       };
     }
-    if (!targetSection.title?.trim()) {
+    involved.push({
+      label: 'translation',
+      documentId: targetDocumentId,
+      sectionId: targetSection?.id ?? null,
+      getValue: (row) => row.target,
+      write: wantsTarget && !!targetSection,
+    });
+
+    // Reference documents — every non-origin/translation column, headed by a
+    // reference document's key. Resolve each to the project's reference document
+    // and its counterpart section; unresolved columns are reported, not imported.
+    const fileReferenceKeys = [
+      ...new Set(rows.flatMap((r) => r.references.map((ref) => ref.sutraName).filter((k): k is string => !!k))),
+    ];
+    const project = await DbProjects.findBySourceDocumentId(originDocumentId);
+    const projectReferences = project ? await DbProjectReferences.findByProjectId(project.id) : [];
+    const referenceByKey = new Map(
+      projectReferences
+        .filter((ref) => ref.document?.key)
+        .map((ref) => [normaliseKey(ref.document.key as string), ref] as const),
+    );
+
+    for (const columnKey of fileReferenceKeys) {
+      const ref = referenceByKey.get(normaliseKey(columnKey));
+      if (!ref) {
+        skippedColumns.push(`"${columnKey}" (not a reference document on this project)`);
+        continue;
+      }
+      const refSection = await findTargetSection({
+        sourceSection: { order: sectionOrder },
+        targetDocumentId: ref.documentId,
+      });
+      if (!refSection || !refSection.title?.trim()) {
+        skippedColumns.push(`"${columnKey}" (its section is missing or unnamed — create and name it first)`);
+        continue;
+      }
+      involved.push({
+        label: columnKey,
+        documentId: ref.documentId,
+        sectionId: refSection.id,
+        getValue: (row) => row.references.find((r) => r.sutraName === columnKey)?.content ?? null,
+        write: true,
+      });
+    }
+
+    const writeDocs = involved.filter((d) => d.write && d.sectionId);
+    if (writeDocs.length === 0) {
       return {
         success: false,
         message:
-          'The translation section exists but has no title. ' +
-          'Name it in Data Management → Translation Projects (edit the section and set a translation title) before importing.',
+          skippedColumns.length > 0
+            ? `Nothing was imported. Skipped column(s): ${skippedColumns.join('; ')}.`
+            : 'No importable content found. The file has no columns matching a document key (origin, translation or a reference key).',
       };
     }
+
+    // Sections to load for alignment: every involved document that has a section,
+    // whether or not it is being written (existing data anchors the row keys).
+    const anchorSectionIds = [...new Set(involved.map((d) => d.sectionId).filter((s): s is string => !!s))];
 
     const { counts, algoliaUpdates, algoliaInserts } = await db.transaction(async (tx) => {
-      // ── 1. Load existing rows (non-parked) for both sides ────────────────
-      const existingOrigins = await tx.query.paragraphsTableNew.findMany({
-        where: (p, { eq, and, gte }) => and(eq(p.sectionId, originSectionId), gte(p.order, 0)),
-        orderBy: (p, { asc }) => [asc(p.order)],
-      });
-      const existingTargets = await tx.query.paragraphsTableNew.findMany({
-        where: (p, { eq, and, gte }) => and(eq(p.sectionId, targetSection.id), gte(p.order, 0)),
-        orderBy: (p, { asc }) => [asc(p.order)],
-      });
-      const targetsByPassageKey = new Map(
-        existingTargets.filter((t) => t.passageKey).map((t) => [t.passageKey as string, t]),
-      );
+      const existingBySection = new Map<string, ReadParagraphNew[]>();
+      for (const sid of anchorSectionIds) {
+        existingBySection.set(
+          sid,
+          await tx.query.paragraphsTableNew.findMany({
+            where: (p, { eq, and, gte }) => and(eq(p.sectionId, sid), gte(p.order, 0)),
+            orderBy: (p, { asc }) => [asc(p.order)],
+          }),
+        );
+      }
 
-      let updatedCount = 0;
-      let insertedCount = 0;
+      const paraAtOrder = (sectionId: string, order: number) =>
+        (existingBySection.get(sectionId) ?? []).find((p) => p.order === order);
+      const paraWithKey = (sectionId: string, key: string) =>
+        (existingBySection.get(sectionId) ?? []).find((p) => p.passageKey === key);
 
-      // Collected during the loop; executed in bulk after.
-      const updateOps: { id: string; data: Partial<CreateParagraphNew> }[] = [];
-      const insertRows: CreateParagraphNew[] = [];
-      const algoliaUpdates: { searchId: string; data: object }[] = [];
-      const algoliaInserts: CreateParagraphNew[] = [];
-
-      // ── 2. Classify rows into update vs insert buckets ───────────────────
+      // ── 1. Decide each row's shared passage key and canonical order ─────────
+      const rowKeys: string[] = [];
+      const rowOrders: number[] = [];
       for (let idx = 0; idx < rows.length; idx++) {
-        const row = rows[idx];
-        const existing = existingOrigins[idx];
-        const paraOrder = idx + 1;
-        // Keep an existing origin's key so its target stays attached; only new
-        // rows get a generated key.
-        const passageKey = existing?.passageKey ?? `${passageKeyPrefix}.${originSection.order}.${paraOrder}`;
+        const fileKey = rows[idx].passageKey?.trim() || null;
+        const positionOrder = idx + 1;
 
-        if (existing) {
-          const originData = { content: row.origin, order: paraOrder, passageKey, updatedBy: userId };
-          updateOps.push({ id: existing.id, data: originData });
-          if (existing.searchId) {
-            algoliaUpdates.push({ searchId: existing.searchId, data: originData });
+        if (fileKey) {
+          // Match by key when any anchor already stores it, inheriting its order.
+          const keyed = anchorSectionIds.map((sid) => paraWithKey(sid, fileKey)).find(Boolean);
+          if (keyed) {
+            rowKeys.push(fileKey);
+            rowOrders.push(keyed.order);
+            continue;
           }
-          updatedCount++;
-        } else {
-          const newOrigin: CreateParagraphNew = {
-            id: uuidv4(),
-            documentId: originDocumentId,
-            sectionId: originSectionId,
-            order: paraOrder,
-            passageKey,
-            content: row.origin,
-            searchId: uuidv4(),
-            createdBy: userId,
-            updatedBy: userId,
-          };
-          insertRows.push(newOrigin);
-          algoliaInserts.push(newOrigin);
-          insertedCount++;
+          // A brand-new key can't land on a position already keyed to something else.
+          const clash = anchorSectionIds
+            .map((sid) => paraAtOrder(sid, positionOrder))
+            .find((p) => p?.passageKey && p.passageKey !== fileKey);
+          if (clash) {
+            throw new ImportConflictError(
+              `Row ${idx + 1}: passage_key "${fileKey}" is new, but position ${positionOrder} already holds a ` +
+                `paragraph keyed "${clash.passageKey}". Reconcile the passage keys / row order in the database ` +
+                `(via Data Management / the inspector) so the file agrees with existing data, then re-import.`,
+            );
+          }
+          rowKeys.push(fileKey);
+          rowOrders.push(positionOrder);
+          continue;
         }
 
-        if (row.target) {
-          const existingTarget = targetsByPassageKey.get(passageKey);
-          if (existingTarget) {
-            const targetData = { content: row.target, order: paraOrder, updatedBy: userId };
-            updateOps.push({ id: existingTarget.id, data: targetData });
-            if (existingTarget.searchId) {
-              algoliaUpdates.push({ searchId: existingTarget.searchId, data: targetData });
-            }
+        // No passage_key column — align by position, using the key already stored
+        // at that position. All documents that carry one must agree.
+        const keysAtOrder = new Set(
+          anchorSectionIds.map((sid) => paraAtOrder(sid, positionOrder)?.passageKey).filter((k): k is string => !!k),
+        );
+        if (keysAtOrder.size > 1) {
+          throw new ImportConflictError(
+            `Row ${idx + 1} (position ${positionOrder}): existing documents disagree on the passage key here ` +
+              `(${[...keysAtOrder].join(', ')}). Reconcile them in the database so each position has one key, then re-import.`,
+          );
+        }
+        rowKeys.push([...keysAtOrder][0] ?? `${passageKeyPrefix}.${sectionOrder}.${positionOrder}`);
+        rowOrders.push(positionOrder);
+      }
+
+      // ── 2. Reconcile one document's section against the rows ──────────────
+      // Pure upsert: rows present in the file are updated (matched by passage key,
+      // else by an unkeyed row at the same position) or inserted. Existing
+      // paragraphs the file doesn't mention are left untouched — nothing is
+      // removed — so a file can carry only the rows that need changing.
+      const reconcile = (doc: InvolvedDocument, existing: ReadParagraphNew[]) => {
+        const byKey = new Map(existing.filter((p) => p.passageKey).map((p) => [p.passageKey as string, p]));
+        const byOrder = new Map(existing.map((p) => [p.order, p]));
+        const updates: { id: string; data: Partial<CreateParagraphNew> }[] = [];
+        const inserts: CreateParagraphNew[] = [];
+        const aUpdates: { searchId: string; data: object }[] = [];
+        const aInserts: CreateParagraphNew[] = [];
+
+        for (let idx = 0; idx < rows.length; idx++) {
+          const key = rowKeys[idx];
+          const order = rowOrders[idx];
+          const value = doc.getValue(rows[idx]);
+
+          // No content for this document on this row — nothing to upsert.
+          if (value == null || value.trim() === '') continue;
+
+          let match = byKey.get(key);
+          if (!match) {
+            const pos = byOrder.get(order);
+            // Only reuse the positional row when it is unkeyed; a keyed row
+            // belongs to a different passage and must not be overwritten.
+            if (pos && !pos.passageKey) match = pos;
+          }
+
+          if (match) {
+            const data: Partial<CreateParagraphNew> = { content: value, order, passageKey: key, updatedBy: userId };
+            updates.push({ id: match.id, data });
+            if (match.searchId) aUpdates.push({ searchId: match.searchId, data });
           } else {
-            const newTarget: CreateParagraphNew = {
+            const newRow: CreateParagraphNew = {
               id: uuidv4(),
-              documentId: targetDocumentId,
-              sectionId: targetSection.id,
-              order: paraOrder,
-              passageKey,
-              content: row.target,
+              documentId: doc.documentId,
+              sectionId: doc.sectionId as string,
+              order,
+              passageKey: key,
+              content: value,
               searchId: uuidv4(),
               createdBy: userId,
               updatedBy: userId,
             };
-            insertRows.push(newTarget);
-            algoliaInserts.push(newTarget);
+            inserts.push(newRow);
+            aInserts.push(newRow);
           }
         }
-      }
 
-      // ── 2b. Bulk operations for all collected rows ───────────────────────
+        return { updates, inserts, aUpdates, aInserts };
+      };
+
+      const results = writeDocs.map((doc) => reconcile(doc, existingBySection.get(doc.sectionId as string) ?? []));
+
+      const updateOps = results.flatMap((r) => r.updates);
+      const insertRows = results.flatMap((r) => r.inserts);
+      const algoliaUpdates = results.flatMap((r) => r.aUpdates);
+      const algoliaInserts = results.flatMap((r) => r.aInserts);
+
+      // ── 3. Bulk-execute all collected operations ──────────────────────────
       await Promise.all(
         updateOps.map((op) => tx.update(paragraphsTableNew).set(op.data).where(eq(paragraphsTableNew.id, op.id))),
       );
@@ -500,26 +642,11 @@ export async function replaceSectionData(
         await tx.insert(paragraphsTableNew).values(insertRows);
       }
 
-      // ── 3. Park extra existing paragraphs (negate order) ─────────────────
-      const extras = existingOrigins.slice(rows.length);
-      const parkOps: { id: string; order: number }[] = [];
-      for (const extra of extras) {
-        parkOps.push({ id: extra.id, order: extra.order > 0 ? -extra.order : extra.order });
-        const extraTarget = extra.passageKey ? targetsByPassageKey.get(extra.passageKey) : undefined;
-        if (extraTarget) {
-          parkOps.push({ id: extraTarget.id, order: extraTarget.order > 0 ? -extraTarget.order : extraTarget.order });
-        }
-      }
-      await Promise.all(
-        parkOps.map((op) =>
-          tx
-            .update(paragraphsTableNew)
-            .set({ order: op.order, updatedBy: userId })
-            .where(eq(paragraphsTableNew.id, op.id)),
-        ),
-      );
-
-      return { counts: { updatedCount, insertedCount, parkedCount: extras.length }, algoliaUpdates, algoliaInserts };
+      return {
+        counts: { updatedCount: updateOps.length, insertedCount: insertRows.length },
+        algoliaUpdates,
+        algoliaInserts,
+      };
     });
 
     // ── 4. Sync to Algolia after the transaction commits ─────────────────
@@ -537,21 +664,19 @@ export async function replaceSectionData(
       console.error('Algolia sync errors after import:', searchErrors);
     }
 
-    // References still live on the legacy tables — surface what was skipped.
-    const skippedReferences = rows.reduce((n, r) => n + r.references.filter((x) => x.sutraName && x.content).length, 0);
-
+    const writtenLabels = writeDocs.map((d) => d.label).join(', ');
     return {
       success: true,
       inserted: counts.insertedCount,
-      deleted: counts.parkedCount,
       message:
-        `Updated ${counts.updatedCount} paragraph(s), inserted ${counts.insertedCount} new, parked ${counts.parkedCount} extra.` +
-        (skippedReferences > 0
-          ? ` ${skippedReferences} reference cell(s) were skipped — references are not yet part of the new data model.`
-          : ''),
+        `Updated ${counts.updatedCount} paragraph(s) and inserted ${counts.insertedCount} new across ${writeDocs.length} document(s) (${writtenLabels}). Existing rows not in the file were left unchanged.` +
+        (skippedColumns.length > 0 ? ` Skipped column(s): ${skippedColumns.join('; ')}.` : ''),
       ...(searchErrors.length > 0 && { errors: searchErrors }),
     };
   } catch (error) {
+    if (error instanceof ImportConflictError) {
+      return { success: false, message: error.message, errors: [error.message] };
+    }
     console.error('replaceSectionData error:', error);
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     return {
@@ -564,29 +689,61 @@ export async function replaceSectionData(
 
 /**
  * Preview of the existing paragraphs_new data for a section — what the import
- * page shows before the user confirms a replace. Targets are paired from the
- * project's target document via passage_key; references are always empty here
- * (still legacy-only).
+ * page shows before the user confirms an import. The translation is paired from
+ * the project's target document via passage_key; each reference document's
+ * paragraph sharing the same passage_key is shown as a reference column (labelled
+ * by the reference document's key).
  */
 export async function getExistingDataPreviewForSection(
   sectionId: string,
   targetDocumentId?: string | null,
+  referenceDocuments: { id: string; key: string | null }[] = [],
 ): Promise<ExistingDataPreview> {
   const paragraphs = await readParagraphsBySectionId({
     sectionId,
     targetDocumentId: targetDocumentId ?? undefined,
   });
 
-  return {
-    paragraphs: paragraphs.slice(0, PREVIEW_LIMIT).map((p) => ({
+  const preview = paragraphs.slice(0, PREVIEW_LIMIT);
+  const passageKeys = preview.map((p) => p.passageKey).filter((k): k is string => !!k);
+
+  // For each keyed reference document, map passage_key → its paragraph so we can
+  // attach reference content to the matching preview row.
+  const keyedReferences = referenceDocuments.filter((ref) => ref.key);
+  const referenceParagraphs = await Promise.all(
+    keyedReferences.map(async (ref) => {
+      const paras = passageKeys.length ? await DbParagraphsNew.findByDocumentIdAndPassageKeys(ref.id, passageKeys) : [];
+      const byPassageKey = new Map(paras.filter((p) => p.passageKey).map((p) => [p.passageKey as string, p]));
+      return { key: ref.key as string, byPassageKey };
+    }),
+  );
+
+  let totalReferences = 0;
+  const previewParagraphs = preview.map((p) => {
+    const references = p.passageKey
+      ? referenceParagraphs
+          .map(({ key, byPassageKey }) => {
+            const refPara = byPassageKey.get(p.passageKey as string);
+            return refPara
+              ? { id: refPara.id, order: String(refPara.order), sutraName: key, content: refPara.content }
+              : null;
+          })
+          .filter((r): r is NonNullable<typeof r> => r !== null)
+      : [];
+    totalReferences += references.length;
+    return {
       id: p.id,
       order: String(p.order),
       origin: p.origin,
       targetId: p.targetId,
       target: p.target,
-      references: [],
-    })),
+      references,
+    };
+  });
+
+  return {
+    paragraphs: previewParagraphs,
     totalParagraphs: paragraphs.length,
-    totalReferences: 0,
+    totalReferences,
   };
 }

--- a/app/services/file.service.ts
+++ b/app/services/file.service.ts
@@ -27,18 +27,59 @@ import { type IParagraph } from './paragraph.service';
 export interface ExcelTranslationRow {
   origin: string;
   target: string | null;
+  // Optional passage key supplied by a `passage_key` column. When present it is
+  // the shared identity for this row across every document (origin, translation
+  // and references), so re-imports can match paragraphs by key instead of
+  // position. Null when the file has no passage_key column.
+  passageKey: string | null;
+  // Reference cells keyed by column header — the header is the reference
+  // document's key (see reference importing in file.server.ts).
   references: { sutraName?: string; content?: string }[];
 }
 
 const COLUMN_HEADERS_ORIGIN = 'Origin';
 const COLUMN_HEADERS_TARGET = 'Translation';
 
-const HEADER_ALIASES: Record<string, 'origin' | 'target'> = {
-  origin: 'origin',
-  original: 'origin',
-  target: 'target',
-  translation: 'target',
-};
+// Columns are identified by each document's `key`: the origin document's key
+// heads the origin column, the translation document's key heads the translation
+// column, and each reference document's key heads its own column. The importer
+// passes the origin/target keys in (either may be null if that document has no
+// key); a `passage_key` column is the one reserved header that never maps to a
+// document. Every column is optional — a file may carry any subset of the
+// documents (see file.server.ts); the service aligns them by passage key and/or
+// position.
+export interface ImportColumnKeys {
+  originKey: string | null;
+  targetKey: string | null;
+}
+
+const PASSAGE_KEY_HEADERS = new Set(['passage_key', 'passagekey', 'passage key']);
+
+const normaliseHeader = (header: string): string => header.trim().toLowerCase();
+
+// Classify a file's headers against the document keys. Origin/target are matched
+// by key (case-insensitive) when their key is known; the reserved passage_key
+// header is pulled out; every remaining non-empty header is a reference column
+// (its text is the reference document key).
+function classifyHeaders(headers: string[], keys: ImportColumnKeys) {
+  const originKey = keys.originKey ? normaliseHeader(keys.originKey) : null;
+  const targetKey = keys.targetKey ? normaliseHeader(keys.targetKey) : null;
+
+  const originHeader = originKey ? headers.find((h) => normaliseHeader(h) === originKey) : undefined;
+  const targetHeader = targetKey ? headers.find((h) => normaliseHeader(h) === targetKey) : undefined;
+  const passageHeader = headers.find((h) => PASSAGE_KEY_HEADERS.has(normaliseHeader(h)));
+  const refHeaders = headers.filter(
+    (h) => h.trim() !== '' && h !== originHeader && h !== targetHeader && h !== passageHeader,
+  );
+
+  return { originHeader, targetHeader, passageHeader, refHeaders };
+}
+
+// A row carries no data when every document cell is empty and no passage key is
+// given — such rows are dropped so blank spacer lines don't create paragraphs.
+function isEmptyRow(row: ExcelTranslationRow): boolean {
+  return !row.origin && !row.target && !row.passageKey && row.references.length === 0;
+}
 
 // =============================================================================
 // SECTION 2: Application-layer types
@@ -124,36 +165,36 @@ function getCellText(value: ExcelJS.CellValue): string {
 // SECTION 5: Parsing — CSV and XLSX → ExcelTranslationRow[]
 // =============================================================================
 
-export async function parseCSV(fileContent: string): Promise<ExcelTranslationRow[]> {
+export async function parseCSV(fileContent: string, keys: ImportColumnKeys): Promise<ExcelTranslationRow[]> {
   return new Promise<ExcelTranslationRow[]>((resolve, reject) => {
-    // No transformHeader — we need the original case for reference sutraNames.
+    // No transformHeader — we need the original case for reference document keys.
     Papa.parse<Record<string, string>>(fileContent, {
       header: true,
       skipEmptyLines: true,
 
       complete: (results: Papa.ParseResult<Record<string, string>>): void => {
-        const headers = results.meta.fields ?? [];
+        try {
+          const headers = results.meta.fields ?? [];
+          const { originHeader, targetHeader, passageHeader, refHeaders } = classifyHeaders(headers, keys);
 
-        const originHeader = headers.find((h) => HEADER_ALIASES[h.toLowerCase().trim()] === 'origin');
-        const targetHeader = headers.find((h) => HEADER_ALIASES[h.toLowerCase().trim()] === 'target');
-        const refHeaders = headers.filter((h) => !HEADER_ALIASES[h.toLowerCase().trim()]);
+          const rows: ExcelTranslationRow[] = results.data
+            .map((raw): ExcelTranslationRow => {
+              const origin = originHeader ? (raw[originHeader]?.trim() ?? '') : '';
+              const target = targetHeader ? raw[targetHeader]?.trim() : '';
+              const passageKey = passageHeader ? raw[passageHeader]?.trim() || null : null;
 
-        const rows: ExcelTranslationRow[] = results.data
-          .map((raw): ExcelTranslationRow | null => {
-            const origin = originHeader ? raw[originHeader]?.trim() : '';
-            if (!origin) return null;
+              const references = refHeaders
+                .map((h) => ({ sutraName: h, content: raw[h]?.trim() || '' }))
+                .filter((r) => r.content);
 
-            const target = targetHeader ? raw[targetHeader]?.trim() : '';
+              return { origin, target: target || null, passageKey, references };
+            })
+            .filter((row) => !isEmptyRow(row));
 
-            const references = refHeaders
-              .map((h) => ({ sutraName: h, content: raw[h]?.trim() || '' }))
-              .filter((r) => r.content);
-
-            return { origin, target: target || null, references };
-          })
-          .filter((row): row is ExcelTranslationRow => row !== null);
-
-        resolve(rows);
+          resolve(rows);
+        } catch (error) {
+          reject(error);
+        }
       },
 
       error: (error: Error): void => reject(error),
@@ -161,7 +202,7 @@ export async function parseCSV(fileContent: string): Promise<ExcelTranslationRow
   });
 }
 
-export async function parseXLSX(fileBuffer: ArrayBuffer): Promise<ExcelTranslationRow[]> {
+export async function parseXLSX(fileBuffer: ArrayBuffer, keys: ImportColumnKeys): Promise<ExcelTranslationRow[]> {
   const ExcelJS = await import('exceljs');
 
   const workbook = new ExcelJS.default.Workbook();
@@ -169,46 +210,43 @@ export async function parseXLSX(fileBuffer: ArrayBuffer): Promise<ExcelTranslati
 
   const worksheet = workbook.worksheets[0];
   if (!worksheet) {
-    return [];
+    throw new Error('The workbook has no worksheets.');
   }
 
   const headerRow = worksheet.getRow(1);
-  const columnMapping: Map<number, 'origin' | 'target'> = new Map();
-  // colNumber → original header text (preserved case) for reference columns
-  const refCols: Map<number, string> = new Map();
-
+  // colNumber → header text, preserving order/case so we can classify columns
+  // and, for reference columns, use the header as the reference document key.
+  const headersByCol: { col: number; header: string }[] = [];
   headerRow.eachCell({ includeEmpty: true }, (cell, colNumber) => {
-    const originalHeader = getCellText(cell.value).trim();
-    const canonical = HEADER_ALIASES[originalHeader.toLowerCase()];
-    if (canonical) {
-      columnMapping.set(colNumber, canonical);
-    } else if (originalHeader) {
-      refCols.set(colNumber, originalHeader);
-    }
+    const header = getCellText(cell.value).trim();
+    if (header) headersByCol.push({ col: colNumber, header });
   });
 
-  const originCol = [...columnMapping.entries()].find(([, v]) => v === 'origin')?.[0];
-  if (originCol === undefined) {
-    return [];
-  }
+  const headers = headersByCol.map((h) => h.header);
+  const { originHeader, targetHeader, passageHeader, refHeaders } = classifyHeaders(headers, keys);
 
-  const targetCol = [...columnMapping.entries()].find(([, v]) => v === 'target')?.[0];
+  const colOf = (header: string | undefined) =>
+    header === undefined ? undefined : headersByCol.find((h) => h.header === header)?.col;
+  const originCol = colOf(originHeader);
+  const targetCol = colOf(targetHeader);
+  const passageCol = colOf(passageHeader);
+  const refCols = refHeaders.map((header) => ({ col: colOf(header)!, sutraName: header }));
 
   const rows: ExcelTranslationRow[] = [];
 
   worksheet.eachRow((row, rowNumber) => {
     if (rowNumber === 1) return;
 
-    const origin = getCellText(row.getCell(originCol).value).trim();
-    if (!origin) return;
-
+    const origin = originCol ? getCellText(row.getCell(originCol).value).trim() : '';
     const target = targetCol ? getCellText(row.getCell(targetCol).value).trim() : '';
+    const passageKey = passageCol ? getCellText(row.getCell(passageCol).value).trim() || null : null;
 
-    const references = [...refCols.entries()]
-      .map(([colNum, sutraName]) => ({ sutraName, content: getCellText(row.getCell(colNum).value).trim() }))
+    const references = refCols
+      .map(({ col, sutraName }) => ({ sutraName, content: getCellText(row.getCell(col).value).trim() }))
       .filter((r) => r.content);
 
-    rows.push({ origin, target: target || null, references });
+    const parsed: ExcelTranslationRow = { origin, target: target || null, passageKey, references };
+    if (!isEmptyRow(parsed)) rows.push(parsed);
   });
 
   return rows;
@@ -294,6 +332,7 @@ export function toExcelRow(paragraph: IParagraph): ExcelTranslationRow {
   return {
     origin: paragraph.origin,
     target: paragraph.target,
+    passageKey: null,
     references: paragraph.references.map((r) => ({
       sutraName: r.sutraName,
       content: r.content,

--- a/app/services/project.crud.ts
+++ b/app/services/project.crud.ts
@@ -32,7 +32,15 @@ export const DbProjects = {
         },
         team: true,
         references: {
-          with: { document: true },
+          with: {
+            document: {
+              with: {
+                sections: {
+                  orderBy: (sections, { asc }) => [asc(sections.order)],
+                },
+              },
+            },
+          },
           orderBy: (references, { asc }) => [asc(references.order)],
         },
       },
@@ -62,7 +70,15 @@ export const DbProjects = {
         },
         team: true,
         references: {
-          with: { document: true },
+          with: {
+            document: {
+              with: {
+                sections: {
+                  orderBy: (sections, { asc }) => [asc(sections.order)],
+                },
+              },
+            },
+          },
           orderBy: (references, { asc }) => [asc(references.order)],
         },
       },

--- a/functional/test-import.ts
+++ b/functional/test-import.ts
@@ -49,7 +49,7 @@ async function testCSV() {
   console.log('── CSV input ────────────────────────────────────────');
   console.log(csv);
 
-  const rows = await parseCSV(csv);
+  const rows = await parseCSV(csv, { originKey: 'origin', targetKey: 'translation' });
 
   console.log('\n── Parsed CSV rows ──────────────────────────────────');
   console.log(JSON.stringify(rows, null, 2));
@@ -83,7 +83,7 @@ async function testXLSX() {
   ws.addRow({ origin: '自性本清淨', target: '', ref1: '', ref2: 'Platform Sutra v3' });
 
   const buffer = await wb.xlsx.writeBuffer();
-  const rows = await parseXLSX(buffer as ArrayBuffer);
+  const rows = await parseXLSX(buffer as ArrayBuffer, { originKey: 'origin', targetKey: 'translation' });
 
   console.log('\n── Parsed XLSX rows ─────────────────────────────────');
   console.log(JSON.stringify(rows, null, 2));
@@ -116,9 +116,10 @@ async function testDB() {
     {
       origin: 'Test origin 1',
       target: 'Test translation 1',
+      passageKey: null,
       references: [{ sutraName: 'Test Sutra', content: 'test ref' }],
     },
-    { origin: 'Test origin 2', target: null, references: [] },
+    { origin: 'Test origin 2', target: null, passageKey: null, references: [] },
   ];
 
   const options = {

--- a/tests/file.server.test.ts
+++ b/tests/file.server.test.ts
@@ -66,8 +66,13 @@ const BASE_OPTIONS: ImportOptions = {
 };
 
 const TWO_ROWS: ExcelTranslationRow[] = [
-  { origin: '諸法因緣生', target: 'All dharmas arise', references: [{ sutraName: 'Diamond Sutra', content: 'ref-a' }] },
-  { origin: '諸法因緣滅', target: null, references: [] },
+  {
+    origin: '諸法因緣生',
+    target: 'All dharmas arise',
+    passageKey: null,
+    references: [{ sutraName: 'Diamond Sutra', content: 'ref-a' }],
+  },
+  { origin: '諸法因緣滅', target: null, passageKey: null, references: [] },
 ];
 
 // ─── buildImportData ─────────────────────────────────────────────────────────
@@ -265,8 +270,8 @@ describe('replaceRollData', () => {
 
   describe('when rows have no translations', () => {
     const originOnlyRows: ExcelTranslationRow[] = [
-      { origin: '諸法因緣生', target: null, references: [] },
-      { origin: '諸法因緣滅', target: null, references: [] },
+      { origin: '諸法因緣生', target: null, passageKey: null, references: [] },
+      { origin: '諸法因緣滅', target: null, passageKey: null, references: [] },
     ];
 
     it('inserts only origin paragraphs (no target insert call)', async () => {
@@ -279,7 +284,9 @@ describe('replaceRollData', () => {
   // ── No references ────────────────────────────────────────────────────────
 
   describe('when rows have no references', () => {
-    const noRefRows: ExcelTranslationRow[] = [{ origin: '諸法因緣生', target: 'All dharmas arise', references: [] }];
+    const noRefRows: ExcelTranslationRow[] = [
+      { origin: '諸法因緣生', target: 'All dharmas arise', passageKey: null, references: [] },
+    ];
 
     it('inserts origins and targets but not references', async () => {
       await replaceRollData(noRefRows, BASE_OPTIONS);

--- a/tests/file.service.test.ts
+++ b/tests/file.service.test.ts
@@ -17,9 +17,14 @@ import {
 const makeParagraph = (overrides: Partial<ExcelTranslationRow> = {}): ExcelTranslationRow => ({
   origin: '原文',
   target: 'Translation',
+  passageKey: null,
   references: [],
   ...overrides,
 });
+
+// Columns are identified by document keys; these tests use "origin"/"translation"
+// as the origin/translation document keys.
+const KEYS = { originKey: 'origin', targetKey: 'translation' };
 
 const sampleParagraphs: ExcelTranslationRow[] = [
   makeParagraph({
@@ -220,39 +225,71 @@ describe('buildExportFilename', () => {
 describe('parseCSV', () => {
   it('parses origin and target', async () => {
     const csv = `origin,translation\n諸法因緣生,All dharmas arise\n諸法因緣滅,All dharmas cease`;
-    const rows = await parseCSV(csv);
+    const rows = await parseCSV(csv, KEYS);
     expect(rows).toHaveLength(2);
     expect(rows[0]).toMatchObject({ origin: '諸法因緣生', target: 'All dharmas arise', references: [] });
     expect(rows[1]).toMatchObject({ origin: '諸法因緣滅', target: 'All dharmas cease', references: [] });
   });
 
-  it('accepts header aliases (original / target)', async () => {
-    const csv = `original,target\nfoo,bar`;
-    const rows = await parseCSV(csv);
+  it('matches columns by document key', async () => {
+    const csv = `original,rendering\nfoo,bar`;
+    const rows = await parseCSV(csv, { originKey: 'original', targetKey: 'rendering' });
     expect(rows[0]).toMatchObject({ origin: 'foo', target: 'bar' });
   });
 
-  it('is case-insensitive for known headers (Origin, TRANSLATION)', async () => {
+  it('matches keys case-insensitively (Origin, TRANSLATION)', async () => {
     const csv = `Origin,TRANSLATION\nfoo,bar`;
-    const rows = await parseCSV(csv);
+    const rows = await parseCSV(csv, KEYS);
     expect(rows[0]).toMatchObject({ origin: 'foo', target: 'bar' });
   });
 
-  it('sets target to null when translation column is absent', async () => {
-    const csv = `origin\nfoo`;
-    const rows = await parseCSV(csv);
-    expect(rows[0].target).toBeNull();
+  it('accepts a file with only the translation column (origin absent)', async () => {
+    const rows = await parseCSV(`translation\nbar`, KEYS);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ origin: '', target: 'bar' });
+  });
+
+  it('accepts a file with only the origin column (translation absent)', async () => {
+    const rows = await parseCSV(`origin\nfoo`, KEYS);
+    expect(rows[0]).toMatchObject({ origin: 'foo', target: null });
+  });
+
+  it('accepts a file of only reference columns (no origin/translation)', async () => {
+    const rows = await parseCSV(`Diamond Sutra\nref text`, KEYS);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ origin: '', target: null });
+    expect(rows[0].references).toEqual([{ sutraName: 'Diamond Sutra', content: 'ref text' }]);
+  });
+
+  it('drops fully-empty rows but keeps rows with any content', async () => {
+    const rows = await parseCSV(`origin,translation\n,\n,bar\nfoo,`, KEYS);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({ origin: '', target: 'bar' });
+    expect(rows[1]).toMatchObject({ origin: 'foo', target: null });
+  });
+
+  it('reads a passage_key column into passageKey (and never as a reference)', async () => {
+    const csv = `origin,translation,passage_key\nfoo,bar,T09n0262.1.1`;
+    const rows = await parseCSV(csv, KEYS);
+    expect(rows[0].passageKey).toBe('T09n0262.1.1');
+    expect(rows[0].references).toHaveLength(0);
+  });
+
+  it('leaves passageKey null when there is no passage_key column', async () => {
+    const csv = `origin,translation\nfoo,bar`;
+    const rows = await parseCSV(csv, KEYS);
+    expect(rows[0].passageKey).toBeNull();
   });
 
   it('sets target to null when cell is empty', async () => {
     const csv = `origin,translation\nfoo,`;
-    const rows = await parseCSV(csv);
+    const rows = await parseCSV(csv, KEYS);
     expect(rows[0].target).toBeNull();
   });
 
   it('captures extra columns as references with original-case sutraName', async () => {
     const csv = `origin,translation,Diamond Sutra,Platform Sutra\nfoo,bar,ref-a,ref-b`;
-    const rows = await parseCSV(csv);
+    const rows = await parseCSV(csv, KEYS);
     expect(rows[0].references).toEqual([
       { sutraName: 'Diamond Sutra', content: 'ref-a' },
       { sutraName: 'Platform Sutra', content: 'ref-b' },
@@ -261,26 +298,27 @@ describe('parseCSV', () => {
 
   it('skips reference cells that are empty', async () => {
     const csv = `origin,translation,Diamond Sutra\nfoo,bar,\nbaz,qux,ref`;
-    const rows = await parseCSV(csv);
+    const rows = await parseCSV(csv, KEYS);
     expect(rows[0].references).toHaveLength(0);
     expect(rows[1].references).toHaveLength(1);
   });
 
-  it('skips rows with no origin', async () => {
+  it('keeps an origin-less row when another column has content', async () => {
     const csv = `origin,translation\n,bar\nfoo,baz`;
-    const rows = await parseCSV(csv);
-    expect(rows).toHaveLength(1);
-    expect(rows[0].origin).toBe('foo');
+    const rows = await parseCSV(csv, KEYS);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({ origin: '', target: 'bar' });
+    expect(rows[1]).toMatchObject({ origin: 'foo', target: 'baz' });
   });
 
   it('trims whitespace from cells', async () => {
     const csv = `origin,translation\n  foo  ,  bar  `;
-    const rows = await parseCSV(csv);
+    const rows = await parseCSV(csv, KEYS);
     expect(rows[0]).toMatchObject({ origin: 'foo', target: 'bar' });
   });
 
   it('returns empty array for empty CSV (headers only)', async () => {
-    const rows = await parseCSV('origin,translation\n');
+    const rows = await parseCSV('origin,translation\n', KEYS);
     expect(rows).toHaveLength(0);
   });
 });
@@ -292,25 +330,39 @@ describe('parseXLSX', () => {
     const buf = await buildXlsx(
       [
         { header: 'origin', key: 'origin' },
-        { header: 'Translation', key: 'target' },
+        { header: 'translation', key: 'target' },
       ],
       [{ origin: '諸法因緣生', target: 'All dharmas arise' }],
     );
-    const rows = await parseXLSX(buf);
+    const rows = await parseXLSX(buf, KEYS);
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({ origin: '諸法因緣生', target: 'All dharmas arise', references: [] });
   });
 
-  it('accepts header aliases (original, translation) case-insensitively', async () => {
+  it('matches keys case-insensitively (ORIGIN, TRANSLATION)', async () => {
     const buf = await buildXlsx(
       [
-        { header: 'ORIGINAL', key: 'origin' },
-        { header: 'translation', key: 'target' },
+        { header: 'ORIGIN', key: 'origin' },
+        { header: 'TRANSLATION', key: 'target' },
       ],
       [{ origin: 'foo', target: 'bar' }],
     );
-    const rows = await parseXLSX(buf);
+    const rows = await parseXLSX(buf, KEYS);
     expect(rows[0]).toMatchObject({ origin: 'foo', target: 'bar' });
+  });
+
+  it('reads a passage_key column into passageKey (and never as a reference)', async () => {
+    const buf = await buildXlsx(
+      [
+        { header: 'origin', key: 'origin' },
+        { header: 'translation', key: 'target' },
+        { header: 'passage_key', key: 'passage_key' },
+      ],
+      [{ origin: 'foo', target: 'bar', passage_key: 'T09n0262.1.1' }],
+    );
+    const rows = await parseXLSX(buf, KEYS);
+    expect(rows[0].passageKey).toBe('T09n0262.1.1');
+    expect(rows[0].references).toHaveLength(0);
   });
 
   it('captures extra columns as references preserving header case', async () => {
@@ -322,7 +374,7 @@ describe('parseXLSX', () => {
       ],
       [{ origin: 'foo', target: 'bar', ref1: 'diamond ref' }],
     );
-    const rows = await parseXLSX(buf);
+    const rows = await parseXLSX(buf, KEYS);
     expect(rows[0].references).toEqual([{ sutraName: 'Diamond Sutra', content: 'diamond ref' }]);
   });
 
@@ -338,7 +390,7 @@ describe('parseXLSX', () => {
         { origin: 'baz', target: 'qux', ref1: 'ref text' },
       ],
     );
-    const rows = await parseXLSX(buf);
+    const rows = await parseXLSX(buf, KEYS);
     expect(rows[0].references).toHaveLength(0);
     expect(rows[1].references).toHaveLength(1);
   });
@@ -351,11 +403,11 @@ describe('parseXLSX', () => {
       ],
       [{ origin: 'foo', target: '' }],
     );
-    const rows = await parseXLSX(buf);
+    const rows = await parseXLSX(buf, KEYS);
     expect(rows[0].target).toBeNull();
   });
 
-  it('skips rows where origin is empty', async () => {
+  it('keeps an origin-less row when another column has content', async () => {
     const buf = await buildXlsx(
       [
         { header: 'origin', key: 'origin' },
@@ -366,14 +418,32 @@ describe('parseXLSX', () => {
         { origin: 'foo', target: 'baz' },
       ],
     );
-    const rows = await parseXLSX(buf);
-    expect(rows).toHaveLength(1);
-    expect(rows[0].origin).toBe('foo');
+    const rows = await parseXLSX(buf, KEYS);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({ origin: '', target: 'bar' });
+    expect(rows[1]).toMatchObject({ origin: 'foo', target: 'baz' });
   });
 
-  it('returns empty array when origin column is absent', async () => {
+  it('accepts a file without an origin column', async () => {
     const buf = await buildXlsx([{ header: 'translation', key: 'target' }], [{ target: 'bar' }]);
-    const rows = await parseXLSX(buf);
-    expect(rows).toHaveLength(0);
+    const rows = await parseXLSX(buf, KEYS);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ origin: '', target: 'bar' });
+  });
+
+  it('drops fully-empty rows', async () => {
+    const buf = await buildXlsx(
+      [
+        { header: 'origin', key: 'origin' },
+        { header: 'translation', key: 'target' },
+      ],
+      [
+        { origin: '', target: '' },
+        { origin: 'foo', target: 'bar' },
+      ],
+    );
+    const rows = await parseXLSX(buf, KEYS);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].origin).toBe('foo');
   });
 });


### PR DESCRIPTION
references are now also documents, so the content is saved in paragraphs. they are populated in the projects route.
pure upsert - no paragraphs are parked. that is the origin of the negative order values.
the column header is the document key, for easy labeling.
instructions are updated.
