### PR TITLE
merge glossary import

### DIFF
--- a/app/routes/_app.data.glossary.import.tsx
+++ b/app/routes/_app.data.glossary.import.tsx
@@ -13,6 +13,7 @@ import { Badge } from '~/components/ui/badge';
 import { Button } from '~/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '~/components/ui/card';
 import { Separator } from '~/components/ui/separator';
+import { mergeTranslationsWithStatus, type TranslationStatus } from '~/services/glossary.merge';
 import {
   CHUNK_SIZE,
   chunkGroupsToRows,
@@ -126,6 +127,18 @@ type TermCardProps = {
   variant: 'existing' | 'incoming';
 };
 
+const TRANSLATION_STATUS_LABELS: Record<TranslationStatus, string> = {
+  kept: 'Kept',
+  updated: 'Updated',
+  new: 'New',
+};
+
+const TRANSLATION_STATUS_STYLES: Record<TranslationStatus, string> = {
+  kept: 'bg-muted text-muted-foreground',
+  updated: 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-200',
+  new: 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-200',
+};
+
 function GlossaryTermCard({ group, variant }: TermCardProps) {
   const isIncoming = variant === 'incoming';
   const isNew = !group.existing;
@@ -144,23 +157,32 @@ function GlossaryTermCard({ group, variant }: TermCardProps) {
   const author = isIncoming ? first.author : group.existing!.author;
   const cbetaFrequency = isIncoming ? first.cbetaFrequency : group.existing!.cbetaFrequency;
 
-  const translations = isIncoming
-    ? group.rows
-        .filter((r) => r.englishTerm)
-        .map((r) => ({
-          glossary: r.englishTerm,
-          sutraName: r.sutraName,
-          volume: r.volume,
-          originSutraText: r.chineseSutraText || null,
-          targetSutraText: r.englishSutraText || null,
-        }))
-    : (group.existing?.translations ?? []).map((t) => ({
-        glossary: t.glossary,
-        sutraName: t.sutraName,
-        volume: t.volume,
-        originSutraText: t.originSutraText ?? null,
-        targetSutraText: t.targetSutraText ?? null,
-      }));
+  const stored = (group.existing?.translations ?? []).map((t) => ({
+    glossary: t.glossary,
+    sutraName: t.sutraName,
+    volume: t.volume,
+    originSutraText: t.originSutraText ?? null,
+    targetSutraText: t.targetSutraText ?? null,
+    author: t.author ?? null,
+  }));
+
+  // Mirrors the server's merge in importGlossaries, so the panel shows the row that will
+  // actually be stored — kept translations included, not just the file's rows.
+  const translations: Array<(typeof stored)[number] & { status?: TranslationStatus }> = isIncoming
+    ? mergeTranslationsWithStatus(
+        stored,
+        group.rows
+          .filter((r) => r.englishTerm)
+          .map((r) => ({
+            glossary: r.englishTerm,
+            sutraName: r.sutraName,
+            volume: r.volume,
+            originSutraText: r.chineseSutraText || null,
+            targetSutraText: r.englishSutraText || null,
+            author: r.author || null,
+          })),
+      ).map((m) => ({ ...m.translation, status: m.status }))
+    : stored;
 
   return (
     <div
@@ -193,7 +215,14 @@ function GlossaryTermCard({ group, variant }: TermCardProps) {
         <div className="space-y-1.5 pt-0.5">
           {translations.map((t, i) => (
             <div key={i} className="bg-background text-foreground space-y-0.5 rounded border p-2 text-xs">
-              <p className="font-medium">{t.glossary}</p>
+              <div className="flex items-start justify-between gap-2">
+                <p className="font-medium">{t.glossary}</p>
+                {t.status && (
+                  <span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] ${TRANSLATION_STATUS_STYLES[t.status]}`}>
+                    {TRANSLATION_STATUS_LABELS[t.status]}
+                  </span>
+                )}
+              </div>
               {(t.sutraName || t.volume) && (
                 <p className="text-muted-foreground">{[t.sutraName, t.volume].filter(Boolean).join(' · ')}</p>
               )}
@@ -283,7 +312,8 @@ function ImportInstructions() {
             </li>
             <li>
               <strong>Review</strong> — the left column shows what is currently in the database; the right column shows
-              what the CSV will create or overwrite. Green cards are new entries; amber cards are updates.
+              the entry as it will be stored after the merge. Green cards are new entries; amber cards are updates.
+              Within a card, each translation is tagged <em>Kept</em>, <em>Updated</em> or <em>New</em>.
             </li>
             <li>
               <strong>Import Chunk</strong> — click the button to write the current chunk to the database, then the next
@@ -302,9 +332,20 @@ function ImportInstructions() {
           <p className="text-foreground mb-1 font-medium">Conflict resolution</p>
           <p>
             Rows with a UUID are matched to the existing record by primary key. Rows without a UUID are matched by
-            Chinese term. When a match is found the entry&apos;s metadata (phonetic, author, CBETA frequency) and its
-            full translations list are <strong>replaced</strong> with the CSV values. New entries are created and
-            indexed in Algolia automatically.
+            Chinese term. New entries are created and indexed in Algolia automatically.
+          </p>
+          <p className="mt-2">
+            When a match is found the entry&apos;s translations are <strong>merged</strong>, not replaced — translations
+            already in the database are kept even if the file does not mention them, so an import file only needs to
+            carry the terms it is adding. A translation is considered the same as a stored one when its{' '}
+            <code>EnglishTerm</code>, <code>SutraName</code> and <code>Volume</code> all match; in that case the file
+            wins and the stored sutra text is overwritten. Everything else is appended. Re-importing the same file
+            therefore changes nothing.
+          </p>
+          <p className="mt-2">
+            Entry-level metadata (phonetic, author, CBETA frequency) is overwritten by the file when supplied; leaving a
+            cell blank keeps the stored value. To remove a translation, edit the entry directly — an import cannot
+            delete one.
           </p>
         </div>
       </CardContent>
@@ -592,7 +633,7 @@ export default function GlossaryImportPage() {
               <div className="rounded-lg border p-4">
                 <p className="text-3xl font-bold text-amber-600 dark:text-amber-400">{totals.updated}</p>
                 <p className="text-foreground mt-1 text-sm font-medium">Updated</p>
-                <p className="text-muted-foreground text-xs">existing entries overwritten</p>
+                <p className="text-muted-foreground text-xs">existing entries merged</p>
               </div>
               <div className="rounded-lg border p-4">
                 <p className="text-destructive text-3xl font-bold">{totals.failed}</p>

--- a/app/services/glossary.merge.ts
+++ b/app/services/glossary.merge.ts
@@ -1,0 +1,94 @@
+// Client-safe merging of glossary translation lists.
+//
+// Imported by the browser preview panel as well as the server-side importer, so — like
+// glossary.parse.ts — it must never reach into `~/lib/db.server`, Algolia or OpenAI.
+//
+// Translations live in a single JSON column, so an import that wrote only the file's rows
+// would silently drop every translation the file didn't mention. Import files are expected
+// to carry one source at a time, so incoming rows are merged into what is already stored.
+
+// The fields that identify a translation. Structurally satisfied by both the stored
+// translation shape and the preview's display shape.
+export type MergeableTranslation = {
+  glossary: string;
+  sutraName: string;
+  volume: string;
+  originSutraText?: string | null;
+  targetSutraText?: string | null;
+  author?: string | null;
+};
+
+export type TranslationStatus = 'kept' | 'updated' | 'new';
+
+export type MergedTranslation<T> = {
+  translation: T;
+  status: TranslationStatus;
+};
+
+// Identity of a translation within one glossary entry: the English term plus its source.
+// The same term translated from a different sutra or volume is a separate translation, not
+// a revision of the existing one.
+export function translationKey(t: MergeableTranslation): string {
+  return [t.glossary, t.sutraName, t.volume].map((field) => (field ?? '').trim().toLowerCase()).join('␟');
+}
+
+// Compares only what the file can carry — updatedAt/updatedBy always differ on re-import
+// and would make every unchanged row look like an edit.
+function sameContent(a: MergeableTranslation, b: MergeableTranslation): boolean {
+  const norm = (v?: string | null) => (v ?? '').trim();
+  return (
+    norm(a.originSutraText) === norm(b.originSutraText) &&
+    norm(a.targetSutraText) === norm(b.targetSutraText) &&
+    norm(a.author) === norm(b.author)
+  );
+}
+
+// Merges incoming translations into the stored ones, keyed by translationKey.
+//
+// Stored order is preserved so entries don't reshuffle on every import; matched keys are
+// replaced in place (incoming wins, so corrections still apply) and unmatched incoming
+// translations are appended. Duplicate keys on either side collapse to one, which makes a
+// repeated import of the same file idempotent.
+export function mergeTranslationsWithStatus<T extends MergeableTranslation>(
+  existing: readonly T[] | null | undefined,
+  incoming: readonly T[] | null | undefined,
+): MergedTranslation<T>[] {
+  const incomingByKey = new Map<string, T>();
+  for (const t of incoming ?? []) {
+    const key = translationKey(t);
+    if (!incomingByKey.has(key)) incomingByKey.set(key, t);
+  }
+
+  const merged: MergedTranslation<T>[] = [];
+  const seen = new Set<string>();
+
+  for (const stored of existing ?? []) {
+    const key = translationKey(stored);
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    const replacement = incomingByKey.get(key);
+    if (!replacement) {
+      merged.push({ translation: stored, status: 'kept' });
+    } else if (sameContent(stored, replacement)) {
+      merged.push({ translation: replacement, status: 'kept' });
+    } else {
+      merged.push({ translation: replacement, status: 'updated' });
+    }
+  }
+
+  for (const [key, translation] of incomingByKey) {
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push({ translation, status: 'new' });
+  }
+
+  return merged;
+}
+
+export function mergeTranslations<T extends MergeableTranslation>(
+  existing: readonly T[] | null | undefined,
+  incoming: readonly T[] | null | undefined,
+): T[] {
+  return mergeTranslationsWithStatus(existing, incoming).map((m) => m.translation);
+}

--- a/app/services/glossary.service.ts
+++ b/app/services/glossary.service.ts
@@ -7,6 +7,7 @@ import { getDb } from '~/lib/db.server';
 import algoliaClient from '~/providers/algolia';
 
 import { DbGlossaries } from './glossary.crud';
+import { mergeTranslations } from './glossary.merge';
 import { groupRows, type GlossaryImportRow } from './glossary.parse';
 
 // Re-exported so callers of importGlossaries can reach the row type from one place.
@@ -294,7 +295,8 @@ export const importGlossaries = async (rows: GlossaryImportRow[], userId: string
     const results = await Promise.allSettled(
       batch.map(async (group) => {
         const first = group.rows[0];
-        const translations = group.rows
+        // Typed as the stored shape so it merges with existing.translations without widening.
+        const translations: NonNullable<UpdateGlossary['translations']> = group.rows
           .filter((r) => r.englishTerm)
           .map((r) => ({
             glossary: r.englishTerm,
@@ -319,7 +321,9 @@ export const importGlossaries = async (rows: GlossaryImportRow[], userId: string
             author: first.author || null,
             cbetaFrequency: first.cbetaFrequency || null,
             discussion: existing.discussion ?? null,
-            translations,
+            // Translations are one JSON column: send the merge, not just the file's rows,
+            // or every translation the file omits would be dropped.
+            translations: mergeTranslations(existing.translations, translations),
             updatedBy: userId,
           });
           return 'updated' as const;

--- a/tests/glossary.merge.test.ts
+++ b/tests/glossary.merge.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  mergeTranslations,
+  mergeTranslationsWithStatus,
+  translationKey,
+  type MergeableTranslation,
+} from '~/services/glossary.merge';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeTranslation(overrides: Partial<MergeableTranslation> & { glossary: string }): MergeableTranslation {
+  return {
+    sutraName: '',
+    volume: '',
+    originSutraText: null,
+    targetSutraText: null,
+    author: null,
+    ...overrides,
+  };
+}
+
+// ─── translationKey ──────────────────────────────────────────────────────────
+
+describe('translationKey', () => {
+  it('ignores surrounding whitespace and case', () => {
+    expect(translationKey(makeTranslation({ glossary: ' Bodhisattva ', sutraName: 'Lotus', volume: '1' }))).toBe(
+      translationKey(makeTranslation({ glossary: 'bodhisattva', sutraName: 'lotus', volume: '1' })),
+    );
+  });
+
+  it('separates the same term coming from a different source', () => {
+    expect(translationKey(makeTranslation({ glossary: 'bodhisattva', sutraName: 'Lotus', volume: '1' }))).not.toBe(
+      translationKey(makeTranslation({ glossary: 'bodhisattva', sutraName: 'Lotus', volume: '2' })),
+    );
+  });
+});
+
+// ─── mergeTranslations ───────────────────────────────────────────────────────
+
+describe('mergeTranslations', () => {
+  // The whole point of the merge: an import file carries one source, and everything the
+  // file does not mention has to survive the write.
+  it('keeps stored translations the incoming file does not mention', () => {
+    const stored = [makeTranslation({ glossary: 'bodhisattva', sutraName: 'Lotus', volume: '1' })];
+    const incoming = [makeTranslation({ glossary: 'awakened being', sutraName: 'Diamond', volume: '3' })];
+
+    const merged = mergeTranslations(stored, incoming);
+
+    expect(merged.map((t) => t.glossary)).toEqual(['bodhisattva', 'awakened being']);
+  });
+
+  it('lets the incoming file overwrite a stored translation with the same identity', () => {
+    const stored = [
+      makeTranslation({
+        glossary: 'bodhisattva',
+        sutraName: 'Lotus',
+        volume: '1',
+        targetSutraText: 'old rendering',
+      }),
+    ];
+    const incoming = [
+      makeTranslation({
+        glossary: 'bodhisattva',
+        sutraName: 'Lotus',
+        volume: '1',
+        targetSutraText: 'corrected rendering',
+      }),
+    ];
+
+    const merged = mergeTranslations(stored, incoming);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].targetSutraText).toBe('corrected rendering');
+  });
+
+  it('preserves stored order and appends new translations at the end', () => {
+    const stored = [
+      makeTranslation({ glossary: 'a', sutraName: 'S', volume: '1' }),
+      makeTranslation({ glossary: 'b', sutraName: 'S', volume: '2' }),
+    ];
+    const incoming = [
+      makeTranslation({ glossary: 'c', sutraName: 'S', volume: '3' }),
+      makeTranslation({ glossary: 'b', sutraName: 'S', volume: '2', author: 'reviser' }),
+    ];
+
+    expect(mergeTranslations(stored, incoming).map((t) => t.glossary)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('is idempotent — re-importing the same file changes nothing', () => {
+    const incoming = [
+      makeTranslation({ glossary: 'bodhisattva', sutraName: 'Lotus', volume: '1', targetSutraText: 'text' }),
+    ];
+
+    const once = mergeTranslations([], incoming);
+    const twice = mergeTranslations(once, incoming);
+
+    expect(twice).toEqual(once);
+  });
+
+  it('collapses duplicate keys within the incoming file', () => {
+    const incoming = [
+      makeTranslation({ glossary: 'bodhisattva', sutraName: 'Lotus', volume: '1', author: 'first' }),
+      makeTranslation({ glossary: 'bodhisattva', sutraName: 'Lotus', volume: '1', author: 'second' }),
+    ];
+
+    const merged = mergeTranslations([], incoming);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].author).toBe('first');
+  });
+
+  it('handles a null stored list', () => {
+    const incoming = [makeTranslation({ glossary: 'bodhisattva' })];
+    expect(mergeTranslations(null, incoming)).toEqual(incoming);
+  });
+
+  // A metadata-only row (no EnglishTerm) produces no translations at all, which must not
+  // be read as "delete everything".
+  it('leaves stored translations alone when the file carries none', () => {
+    const stored = [makeTranslation({ glossary: 'bodhisattva', sutraName: 'Lotus', volume: '1' })];
+    expect(mergeTranslations(stored, [])).toEqual(stored);
+  });
+});
+
+// ─── mergeTranslationsWithStatus ─────────────────────────────────────────────
+
+describe('mergeTranslationsWithStatus', () => {
+  it('labels each translation by what the import will do to it', () => {
+    const stored = [
+      makeTranslation({ glossary: 'untouched', sutraName: 'S', volume: '1' }),
+      makeTranslation({ glossary: 'revised', sutraName: 'S', volume: '2', targetSutraText: 'old' }),
+    ];
+    const incoming = [
+      makeTranslation({ glossary: 'revised', sutraName: 'S', volume: '2', targetSutraText: 'new' }),
+      makeTranslation({ glossary: 'added', sutraName: 'S', volume: '3' }),
+    ];
+
+    expect(mergeTranslationsWithStatus(stored, incoming).map((m) => [m.translation.glossary, m.status])).toEqual([
+      ['untouched', 'kept'],
+      ['revised', 'updated'],
+      ['added', 'new'],
+    ]);
+  });
+
+  // updatedAt/updatedBy always differ on re-import; only file-carried content counts.
+  it('reports an unchanged re-import as kept rather than updated', () => {
+    const translation = makeTranslation({
+      glossary: 'bodhisattva',
+      sutraName: 'Lotus',
+      volume: '1',
+      targetSutraText: 'text',
+    });
+
+    expect(mergeTranslationsWithStatus([translation], [{ ...translation }]).map((m) => m.status)).toEqual(['kept']);
+  });
+});


### PR DESCRIPTION
instead of an overwrite of existing glossary terms, this appends new translations to the existing database - this allows for incremental additions to the glossary.